### PR TITLE
Added usage instructions to the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # json-rails-logger
-A custom rails logger that outputs json instead of raw text
+A custom rails logger that outputs JSON instead of raw text. As an extra the logger also saves the `request_id` for any log message, in the returned JSON object. The formatter has a couple of changes that are down to preference, but these don't affect the functionality in any way. This gem can be used with any Rails app using the installation steps below.
+
+## Installation
+In your Rails app, add this to your gemfile:\
+`gem 'json_rails_logger', git: 'git@github.com:epimorphics/json-rails-logger.git'`
+
+And this to your environment config:\
+`config.logger = JsonRailsLogger::Logger.new(STDOUT)`
+
+## Running the tests
+Tests are located in the `./test/` folder.
+
+After cloning the repo, first execute:\
+`bundle install`
+
+To run the tests, use:\
+`rake test`


### PR DESCRIPTION
This PR is related to issue #6 . It adds instructions to the README file about how to use the gem in any Rails app, and also run the tests from the repo using rake. I've left out the branch in the installation instructions because I'm going to merge `dev` changes into `main` and do a release after this PR is merged