### PR TITLE
Issue/3 request

### DIFF
--- a/lib/json_rails_logger/constants.rb
+++ b/lib/json_rails_logger/constants.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module JsonRailsLogger
+  REQUEST_ID = :request_id
+end

--- a/lib/json_rails_logger/json_formatter.rb
+++ b/lib/json_rails_logger/json_formatter.rb
@@ -8,11 +8,10 @@ module JsonRailsLogger
       timestp = process_timestamp(timestamp)
       msg = process_message(raw_msg)
 
-      payload = {
-        level: sev,
-        timestamp: timestp,
-        rails_environment: ::Rails.env
-      }
+      payload = { level: sev,
+                  timestamp: timestp,
+                  rails_environment: ::Rails.env,
+                  request_id: Thread.current[JsonRailsLogger::REQUEST_ID] }
 
       payload.merge!(msg)
 

--- a/lib/json_rails_logger/json_formatter.rb
+++ b/lib/json_rails_logger/json_formatter.rb
@@ -12,7 +12,7 @@ module JsonRailsLogger
                   timestamp: timestp,
                   rails_environment: ::Rails.env }
 
-      parload.merge!(x_request_id.to_h)
+      payload.merge!(x_request_id.to_h)
       payload.merge!(msg.to_h)
 
       "#{payload.to_json}\n"

--- a/lib/json_rails_logger/json_formatter.rb
+++ b/lib/json_rails_logger/json_formatter.rb
@@ -10,10 +10,10 @@ module JsonRailsLogger
 
       payload = { level: sev,
                   timestamp: timestp,
-                  rails_environment: ::Rails.env,
-                  request_id: Thread.current[JsonRailsLogger::REQUEST_ID] }
+                  rails_environment: ::Rails.env }
 
-      payload.merge!(msg)
+      parload.merge!(x_request_id.to_h)
+      payload.merge!(msg.to_h)
 
       "#{payload.to_json}\n"
     end
@@ -26,6 +26,11 @@ module JsonRailsLogger
 
     def process_timestamp(timestamp)
       format_datetime(timestamp)
+    end
+
+    def x_request_id
+      x_request_id = Thread.current[JsonRailsLogger::REQUEST_ID]
+      { 'x-request-id': x_request_id } if x_request_id
     end
 
     def process_message(raw_msg)

--- a/lib/json_rails_logger/middleware.rb
+++ b/lib/json_rails_logger/middleware.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative 'constants'
+
+module JsonRailsLogger
+  # Middleware that saves the request_id into a constant
+  # and clears it after usage in the formatter
+  class Middleware
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      request_id = env['action_dispatch.request_id']
+      Thread.current[JsonRailsLogger::REQUEST_ID] = request_id
+      @app.call(env)
+    ensure
+      Thread.current[JsonRailsLogger::REQUEST_ID] = nil
+    end
+  end
+end

--- a/lib/json_rails_logger/railtie.rb
+++ b/lib/json_rails_logger/railtie.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'middleware'
+require_relative 'request_id_middleware'
 
 module JsonRailsLogger
   # This class is used to configure and setup lograge, as well as our gem
@@ -19,8 +19,8 @@ module JsonRailsLogger
     end
 
     initializer 'railtie.configure_rails_initialization' do |app|
-      app.middleware.insert_after ActionDispatch::RequestId,
-                                  JsonRailsLogger::Middleware
+      app.middleware.insert_after(ActionDispatch::RequestId,
+                                  JsonRailsLogger::RequestIdMiddleware)
     end
   end
 end

--- a/lib/json_rails_logger/railtie.rb
+++ b/lib/json_rails_logger/railtie.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'middleware'
+
 module JsonRailsLogger
   # This class is used to configure and setup lograge, as well as our gem
   class Railtie < Rails::Railtie
@@ -14,6 +16,11 @@ module JsonRailsLogger
     config.after_initialize do |app|
       JsonRailsLogger.setup(app) if JsonRailsLogger.enabled?(app)
       Lograge.setup(app) if JsonRailsLogger.enabled?(app)
+    end
+
+    initializer 'railtie.configure_rails_initialization' do |app|
+      app.middleware.insert_after ActionDispatch::RequestId,
+                                  JsonRailsLogger::Middleware
     end
   end
 end

--- a/lib/json_rails_logger/request_id_middleware.rb
+++ b/lib/json_rails_logger/request_id_middleware.rb
@@ -5,7 +5,7 @@ require_relative 'constants'
 module JsonRailsLogger
   # Middleware that saves the request_id into a constant
   # and clears it after usage in the formatter
-  class Middleware
+  class RequestIdMiddleware
     def initialize(app)
       @app = app
     end


### PR DESCRIPTION
This PR is related to issue #3 . It adds a `request_id` field to every log message, regardless if it's a simple webpacker message or a get request message. It does that using some middleware that saves the `request_id` from `action_dispatch` in the current thread and retrieving it in the formatter. Normally the `request_id` gets passed only to log messages that have request info, rather than all the log message, but that changes with the use of the middleware; now every message has it, so it makes it much easier to trace log messages related to a certain request. Also, locally tests pass, so this should be the case here too