### PR TITLE
Renamed x-request-id to request_id in both JSON and code

### DIFF
--- a/lib/json_rails_logger/json_formatter.rb
+++ b/lib/json_rails_logger/json_formatter.rb
@@ -16,7 +16,7 @@ module JsonRailsLogger
       payload = { level: sev,
                   timestamp: timestp }
 
-      payload.merge!(x_request_id.to_h)
+      payload.merge!(request_id.to_h)
       payload.merge!(new_msg.to_h)
 
       "#{payload.to_json}\n"
@@ -32,9 +32,9 @@ module JsonRailsLogger
       format_datetime(timestamp)
     end
 
-    def x_request_id
-      x_request_id = Thread.current[JsonRailsLogger::REQUEST_ID]
-      { 'x-request-id': x_request_id } if x_request_id
+    def request_id
+      request_id = Thread.current[JsonRailsLogger::REQUEST_ID]
+      { 'request_id': request_id } if request_id
     end
 
     def process_message(raw_msg)

--- a/test/formatter_test.rb
+++ b/test/formatter_test.rb
@@ -79,4 +79,17 @@ describe 'JsonRailsLogger::JsonFormatter' do # rubocop:disable Metrics/BlockLeng
     _(json_output['method']).must_equal('GET')
     _(json_output['path']).must_equal('http://fsa-rp-test.epimorphics.net/')
   end
+
+  it 'should correctly add the request id to returning json' do
+    message = "[Webpacker] Everything's up-to-date. Nothing to do"
+    request_id_fixture = { 'request_id' => 'example-8a3fb0-request-30dgh0e-id' }
+
+    fixture.stub :request_id, request_id_fixture do
+      log_output = fixture.call('INFO', timestamp, progname, message)
+      _(log_output).must_be_kind_of(String)
+
+      json_output = JSON.parse(log_output)
+      _(json_output['request_id']).must_equal(request_id_fixture['request_id'])
+    end
+  end
 end


### PR DESCRIPTION
This PR addresses issue #17 , it simply renames the `x-request-id` to `request_id` both in code and JSON response from the formatter. I'll update the version and changelog when merging to `main` since there's also the tests autorun change to cover