### PR TITLE
Skip internal request id generation step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for the JSON Rails Logger gem
 
+## 0.2.2 - 2021-03-02 (Bogdan)
+
+- `request_id` is no longer internally generated if the header is missing from
+  the request, but the field will be missing from the returning JSON instead
+
 ## 0.2.1 - 2021-02-23 (Bogdan)
 
 - Unit tests should now autorun on push and pull_request actions

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    json_rails_logger (0.2.1)
+    json_rails_logger (0.2.2)
       json
       lograge
       railties

--- a/lib/json_rails_logger/request_id_middleware.rb
+++ b/lib/json_rails_logger/request_id_middleware.rb
@@ -11,7 +11,7 @@ module JsonRailsLogger
     end
 
     def call(env)
-      request_id = env['action_dispatch.request_id']
+      request_id = env['HTTP_X_REQUEST_ID']
       Thread.current[JsonRailsLogger::REQUEST_ID] = request_id
       @app.call(env)
     ensure

--- a/lib/json_rails_logger/version.rb
+++ b/lib/json_rails_logger/version.rb
@@ -3,6 +3,6 @@
 module JsonRailsLogger
   MAJOR = 0
   MINOR = 2
-  FIX = 1
+  FIX = 2
   VERSION = "#{MAJOR}.#{MINOR}.#{FIX}"
 end


### PR DESCRIPTION
This PR is related to issue #22 . Normally a request id is either passed on from the web server or internally generated with the [request id middleware](https://github.com/rails/rails/blob/5aaaa1630ae9a71b3c3ecc4dc46074d678c08d67/actionpack/lib/action_dispatch/middleware/request_id.rb). The internally generated one caused issues with checks such as if the app is alive and can connect to the API; this PR fixes that by retrieving the request id straight from the request. If there is no request id header the field in the returned JSON will simply be missing rather than internally generated