### PR TITLE
Ensure all files are listed in the gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for the JSON Rails Logger gem
 
+## 0.3.0 - 2021-07-02
+
+- (Ian) Fix for GH-25: required files were not listed in the gemspec
+
 ## 0.2.2 - 2021-03-02 (Bogdan)
 
 - `timestamp` renamed to `ts` in returning JSON

--- a/json_rails_logger.gemspec
+++ b/json_rails_logger.gemspec
@@ -10,9 +10,15 @@ Gem::Specification.new do |s|
   s.description = 'A custom rails logger that outputs JSON instead of raw text'
   s.authors     = ['Bogdan-Adrian Marc']
   s.email       = 'bogdan.marc@epimorphics.com'
-  s.files       = ['./lib/json_rails_logger.rb']
   s.homepage    = 'https://github.com/epimorphics/json-rails-logger'
   s.license     = 'MIT'
+
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  s.files = Dir.chdir(File.expand_path(__dir__)) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  end
+  s.require_paths = ['lib']
 
   s.add_runtime_dependency 'json'
   s.add_runtime_dependency 'lograge'

--- a/lib/json_rails_logger/version.rb
+++ b/lib/json_rails_logger/version.rb
@@ -2,7 +2,7 @@
 
 module JsonRailsLogger
   MAJOR = 0
-  MINOR = 2
-  FIX = 2
+  MINOR = 3
+  FIX = 0
   VERSION = "#{MAJOR}.#{MINOR}.#{FIX}"
 end


### PR DESCRIPTION
Fix for issue #25: the files in `lib` were not listed in the gemspec, so
when installing the gem to a package registry (e.g. GitHub Packages),
the built artefact was incomplete.
