### PR TITLE
Add the silence method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for the JSON Rails Logger gem
 
+## 0.3.3. - 2022-02-03
+
+- (Ian) Add the `.silence()` method to the base logger
+
 ## 0.3.2 - 2022-02-02
 
 - (Ian) Re-write the README

--- a/lib/json_rails_logger/logger.rb
+++ b/lib/json_rails_logger/logger.rb
@@ -3,6 +3,8 @@
 module JsonRailsLogger
   # The custom logger class that sets up our formatter
   class Logger < ::Logger
+    include ActiveSupport::LoggerSilence
+
     # List of all the arguments with their default values:
     # logdev, shift_age = 0, shift_size = 1_048_576, level: DEBUG,
     # progname: nil, formatter: nil, datetime_format: nil,

--- a/lib/json_rails_logger/version.rb
+++ b/lib/json_rails_logger/version.rb
@@ -3,6 +3,6 @@
 module JsonRailsLogger
   MAJOR = 0
   MINOR = 3
-  FIX = 2
+  FIX = 3
   VERSION = "#{MAJOR}.#{MINOR}.#{FIX}"
 end

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require './lib/json_rails_logger'
+
+describe 'JsonRailsLogger::Logger' do
+  it 'should support the silence method' do
+    buf = StringIO.new
+    fixture = JsonRailsLogger::Logger.new(buf)
+
+    fixture.debug('test step 1')
+    _(buf.string).must_match(/DEBUG.*test step 1/)
+
+    buf.truncate(0)
+    fixture.error('test step 2')
+    _(buf.string).must_match(/ERROR.*test step 2/)
+
+    buf.truncate(0)
+    fixture.silence(Logger::ERROR) do
+      fixture.error('test step 3')
+    end
+    _(buf.string).must_match(/ERROR.*test step 3/)
+
+    buf.truncate(0)
+    fixture.silence(Logger::ERROR) do
+      fixture.debug('test step 4')
+    end
+    _(buf.string).must_equal('')
+  end
+end


### PR DESCRIPTION
Addresses #37. This commit adds support for the `.silence()` protocol on
a logger, which retricts the logger from outputting messages below a
given level of severity.

Without support for this protocol, the logger may throw errors when used
in a Rails instance running in development mode. In dev mode, Rails can
be set to silence calls to log the loading of asset files.
