### PR TITLE
Set the base class to ActiveSupport::Logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.gem
+.byebug_history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for the JSON Rails Logger gem
 
+## 0.3.4 - 2022-02-07
+
+- (Ian) Set the base logger class to `ActiveSupport::Logger` so that it plays
+  better with Rails
+
 ## 0.3.3. - 2022-02-03
 
 - (Ian) Add the `.silence()` method to the base logger

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ currently active HTTP request in every log.
 
 This gem can be used with any Rails app using the installation steps below.
 
+## Internal structure
+
+This logger makes use of [lograge](https://github.com/roidrage/lograge) to
+"attempt to tame Rails' default policy". However, we augment the JSON format
+used by lograge to fit our local requirements, and ensure the HTTP request ID
+is logged where available.
+
 ## Using with a Rails application
 
 In your Rails app, add this to your `Gemfile`:
@@ -68,12 +75,13 @@ To run the tests, use:\
 
 ### `Makefile`
 
-There is a `Makefile` with some shared dev tasks, but this is
-primarily used by the automated publishing workflow.
+There is a `Makefile` with some shared dev tasks.
 
 To check that the gem will build correctly: `make build`
 
 To create the GitHub and Bundler authorisations: `make auth`
+
+To publish the gem to the GitHub package registry: `make publish`
 
 ### Publishing a new version of the gem
 
@@ -84,6 +92,7 @@ To publish a new version of the gem after a bugfix or feature addition:
 2. Update the `CHANGELOG.md` to document the new change
 3. `git tag` the new state with a tag that matches the new version
 4. Push the new tagged release to GitHub
+5. Run `make publish` to push the new gem to the GitHub package registry.
 
 Pushing a tagged version will automatically trigger the publish gem
 workflow, which should result in the gem appearing on the

--- a/lib/json_rails_logger.rb
+++ b/lib/json_rails_logger.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
-require 'logger'
-require 'json'
-require 'rails'
 require 'lograge'
 
-require_relative 'json_rails_logger/railtie' if defined?(Rails)
-
+require_relative 'json_rails_logger/railtie'
+require_relative 'json_rails_logger/constants'
+require_relative 'json_rails_logger/request_id_middleware'
 require_relative 'json_rails_logger/json_formatter'
 require_relative 'json_rails_logger/error'
 require_relative 'json_rails_logger/logger'

--- a/lib/json_rails_logger/logger.rb
+++ b/lib/json_rails_logger/logger.rb
@@ -2,18 +2,18 @@
 
 module JsonRailsLogger
   # The custom logger class that sets up our formatter
-  class Logger < ::Logger
-    include ActiveSupport::LoggerSilence
+  class Logger < ActiveSupport::Logger
+    # Initialize a logger which is opinionated about emitting log messages
+    # in a standard JSON format that meets the expectations of Epimorphics
+    # operations and monitoring tools
+    #
+    # +logdev+ The output device to send log messages to
+    def initialize(logdev)
+      formatter = JsonRailsLogger::JsonFormatter.new
+      formatter.datetime_format = '%Y-%m-%dT%H:%M:%S.%3NZ'
 
-    # List of all the arguments with their default values:
-    # logdev, shift_age = 0, shift_size = 1_048_576, level: DEBUG,
-    # progname: nil, formatter: nil, datetime_format: nil,
-    # binmode: false, shift_period_suffix: '%Y%m%d'
-    def initialize(*args)
-      @formatter = JsonRailsLogger::JsonFormatter.new
-      @formatter.datetime_format = '%Y-%m-%dT%H:%M:%S.%3NZ'
-
-      super(*args, formatter: @formatter)
+      super(logdev, formatter: formatter)
+      @formatter = formatter
     end
   end
 end

--- a/lib/json_rails_logger/railtie.rb
+++ b/lib/json_rails_logger/railtie.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'request_id_middleware'
-
 module JsonRailsLogger
   # This class is used to configure and setup lograge, as well as our gem
   class Railtie < Rails::Railtie
@@ -14,8 +12,10 @@ module JsonRailsLogger
     end
 
     config.after_initialize do |app|
-      JsonRailsLogger.setup(app) if JsonRailsLogger.enabled?(app)
-      Lograge.setup(app) if JsonRailsLogger.enabled?(app)
+      if JsonRailsLogger.enabled?(app)
+        JsonRailsLogger.setup(app)
+        Lograge.setup(app)
+      end
     end
 
     initializer 'railtie.configure_rails_initialization' do |app|

--- a/lib/json_rails_logger/request_id_middleware.rb
+++ b/lib/json_rails_logger/request_id_middleware.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'constants'
-
 module JsonRailsLogger
   # Middleware that saves the request_id into a constant
   # and clears it after usage in the formatter

--- a/lib/json_rails_logger/version.rb
+++ b/lib/json_rails_logger/version.rb
@@ -3,6 +3,6 @@
 module JsonRailsLogger
   MAJOR = 0
   MINOR = 3
-  FIX = 3
+  FIX = 4
   VERSION = "#{MAJOR}.#{MINOR}.#{FIX}"
 end

--- a/test/formatter_test.rb
+++ b/test/formatter_test.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
-
-require './lib/json_rails_logger'
+require './test/test_helper'
 
 describe 'JsonRailsLogger::JsonFormatter' do # rubocop:disable Metrics/BlockLength
   let(:fixture) do

--- a/test/logger_test.rb
+++ b/test/logger_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require 'minitest/autorun'
-require './lib/json_rails_logger'
+require './test/test_helper'
 
 describe 'JsonRailsLogger::Logger' do
   it 'should support the silence method' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,9 @@
 
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
-require 'byebug'
+# enable if required during debugging
+# require 'byebug'
+
 require 'minitest/autorun'
 
 require 'logger'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+
+require 'byebug'
+require 'minitest/autorun'
+
+require 'logger'
+require 'json'
+require 'rails'
+require 'lograge' unless defined?(Lograge)
+
+require 'json_rails_logger'


### PR DESCRIPTION
This commit addresses #39 by setting the base class of the logger to
`ActiveSupport::Logger`, so that `JsonRailsLogger` can always meet the
contract expected by a Rails logger. Without this, errors are seen when
running in development mode with the logger set to `JsonRailsLogger`

This commit also mixes in some minor clean-ups:

- don't require `rails` and other peer dependencies; we assume these
  will be required by applications that have this logger as a dependency
- only require elements of the library from the parent
  `json_rails_logger.rb` file
- re-order the setting of the `@formatter` to override the wired-in
  default in `ActiveSupport::Logger`
- add a shared `test_helper.rb` for the test scripts
