### PR TITLE
Resolves open-ended dependencies warning on publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for the JSON Rails Logger gem
 
+## 0.3.5.1 - 2023-03
+
+- (Jon) Added specific versions to the gemspec dependencies to resolve open-ended
+  dependency warnings when publishing the gem.
+
 ## 0.3.5 - 2023-01
 
 - (Jon) With additional logging being passed into the logger from outside

--- a/json_rails_logger.gemspec
+++ b/json_rails_logger.gemspec
@@ -27,9 +27,11 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'json'
-  spec.add_runtime_dependency 'lograge'
-  spec.add_runtime_dependency 'railties'
+  # * Resolves open-ended dependencies warning on `make publish`
+  # * See https://guides.rubygems.org/specification-reference/ for more information.
+  spec.add_runtime_dependency 'json', '~> 2.3.0'
+  spec.add_runtime_dependency 'lograge', '~> 0.12.0'
+  spec.add_runtime_dependency 'railties', '~> 7.0.0'
 
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake', '~> 13.0.0'
 end

--- a/lib/json_rails_logger/version.rb
+++ b/lib/json_rails_logger/version.rb
@@ -4,7 +4,7 @@ module JsonRailsLogger
   MAJOR = 0
   MINOR = 3
   PATCH = 5
-  SUFFIX = nil
+  SUFFIX = 1
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && '.' + SUFFIX.to_s}"
 
 end


### PR DESCRIPTION
When attempting to build the gem for publishing to the GitHub Package Repository, the CLI warned not to use an open-ended version, e.g. `>=0`, but use a bounded requirement, such as `~> x.y` for gem dependencies specified in the `.gemspec`. Also includes the updated CHANGELOG to reflect this as well as the incremented suffix for the version cadence.
