### PR TITLE
Resolved base dependency versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog for the JSON Rails Logger gem
 
-## 0.3.5.1 - 2023-03
+## 0.3.5.2 - 2023-03
 
+- (Jon) Updated the gemspec to ensure the dependency versions are locked to
+  specific base versions to avoid any potential issues with the gem being used
 - (Jon) Added specific versions to the gemspec dependencies to resolve open-ended
   dependency warnings when publishing the gem.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,34 +1,34 @@
 PATH
   remote: .
   specs:
-    json_rails_logger (0.3.5)
-      json
-      lograge
-      railties
+    json_rails_logger (0.3.5.2)
+      json (~> 2, >= 2.6.3)
+      lograge (~> 0.12.0)
+      railties (>= 6.1.4.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (7.0.4)
-      actionview (= 7.0.4)
-      activesupport (= 7.0.4)
+    actionpack (7.0.4.2)
+      actionview (= 7.0.4.2)
+      activesupport (= 7.0.4.2)
       rack (~> 2.0, >= 2.2.0)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
-    actionview (7.0.4)
-      activesupport (= 7.0.4)
+    actionview (7.0.4.2)
+      activesupport (= 7.0.4.2)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    activesupport (7.0.4)
+    activesupport (7.0.4.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     builder (3.2.4)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.2)
     crass (1.0.6)
     erubi (1.12.0)
     i18n (1.12.0)
@@ -44,22 +44,22 @@ GEM
       nokogiri (>= 1.5.9)
     method_source (1.0.0)
     mini_portile2 (2.8.1)
-    minitest (5.17.0)
-    nokogiri (1.13.10)
+    minitest (5.18.0)
+    nokogiri (1.14.2)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     racc (1.6.2)
-    rack (2.2.5)
+    rack (2.2.6.3)
     rack-test (2.0.2)
       rack (>= 1.3)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.4.4)
+    rails-html-sanitizer (1.5.0)
       loofah (~> 2.19, >= 2.19.1)
-    railties (7.0.4)
-      actionpack (= 7.0.4)
-      activesupport (= 7.0.4)
+    railties (7.0.4.2)
+      actionpack (= 7.0.4.2)
+      activesupport (= 7.0.4.2)
       method_source
       rake (>= 12.2)
       thor (~> 1.0)
@@ -68,16 +68,16 @@ GEM
     request_store (1.5.1)
       rack (>= 1.4)
     thor (1.2.1)
-    tzinfo (2.0.5)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    zeitwerk (2.6.6)
+    zeitwerk (2.6.7)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   json_rails_logger!
-  rake
+  rake (~> 13.0, >= 13.0.6)
 
 BUNDLED WITH
    2.1.4

--- a/json_rails_logger.gemspec
+++ b/json_rails_logger.gemspec
@@ -29,9 +29,9 @@ Gem::Specification.new do |spec|
 
   # * Resolves open-ended dependencies warning on `make publish`
   # * See https://guides.rubygems.org/specification-reference/ for more information.
-  spec.add_runtime_dependency 'json', '~> 2.3.0'
+  spec.add_runtime_dependency 'json', '~> 2', '>= 2.6.3'
   spec.add_runtime_dependency 'lograge', '~> 0.12.0'
-  spec.add_runtime_dependency 'railties', '~> 7.0.0'
+  spec.add_runtime_dependency 'railties', '>= 6.1.4.1'
 
-  spec.add_development_dependency 'rake', '~> 13.0.0'
+  spec.add_development_dependency 'rake', '~> 13.0', '>= 13.0.6'
 end

--- a/lib/json_rails_logger/version.rb
+++ b/lib/json_rails_logger/version.rb
@@ -4,7 +4,7 @@ module JsonRailsLogger
   MAJOR = 0
   MINOR = 3
   PATCH = 5
-  SUFFIX = 1
+  SUFFIX = 2
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && '.' + SUFFIX.to_s}"
 
 end


### PR DESCRIPTION
Updated the `.gemspec` to ensure the dependency versions are locked to specific base versions to avoid any potential issues with the gem being used; updated the changelog and version cadence to reflect the change
