### PR TITLE
Adjusted JSON Output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog for the JSON Rails Logger gem
 
+## 0.3.5.4 - 2023-03-24
+
+- (Jon) Removed the rails specific properties from the JSON output as they are not
+  required by the logging monitors and consume more disk space than desired.
+- (Jon) Reordered the Timestamp and Level properties to match the order of other
+  logs on the Epimorphics system tooling.
+
 ## 0.3.5.3 - 2023-03-10
 
 - (Jon) Added .ruby-version file to ensure the gem is locked to the specific

--- a/lib/json_rails_logger/json_formatter.rb
+++ b/lib/json_rails_logger/json_formatter.rb
@@ -13,8 +13,8 @@ module JsonRailsLogger
       msg = process_message(raw_msg)
       new_msg = format_message(msg)
 
-      payload = { level: sev,
-                  ts: timestp }
+      payload = { ts: timestp,
+                  level: sev}
 
       payload.merge!(request_id.to_h)
       payload.merge!(new_msg.to_h)
@@ -51,7 +51,7 @@ module JsonRailsLogger
 
     # rubocop:disable Metrics/AbcSize
     def format_message(msg)
-      new_msg = { rails: { environment: ::Rails.env } }
+      new_msg = {}
 
       return msg.merge(new_msg) if string_message_field?(msg)
 
@@ -61,7 +61,6 @@ module JsonRailsLogger
       split_msg[0] = normalise_duration(split_msg[0]) if includes_duration?(split_msg[0])
 
       new_msg.merge!(split_msg[0])
-      new_msg[:rails].merge!(split_msg[1])
 
       new_msg
     end

--- a/lib/json_rails_logger/version.rb
+++ b/lib/json_rails_logger/version.rb
@@ -4,7 +4,7 @@ module JsonRailsLogger
   MAJOR = 0
   MINOR = 3
   PATCH = 5
-  SUFFIX = 3
+  SUFFIX = 4
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && '.' + SUFFIX.to_s}"
 
 end


### PR DESCRIPTION
Removed the rails specific properties from the JSON output as they are not required by the logging monitors and consume more disk space than desired.  Also reordered the `TimeStamp`  and `Level` properties to match the order of other logs on the Epimorphics system tooling.
