### PR TITLE
Continued Logging Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,33 @@
 # Changelog for the JSON Rails Logger gem
 
+## 0.3.6.0 - 2023-05-24
+
+- (Jon) After determining the request_id variable was not always being filled in
+  via the `env['HTTP_X_REQUEST_ID']` request,  the rails environment variable
+  `env['action_dispatch.request_id']` was re-added to ensure this value was
+  collected and parsed.
+
 ## 0.3.5.5 - 2023-05-10
 
-- (Jon) Reverted the `gemspec` file to ensure the gem accepts higher ruby versions
-and allows it to work with current app integrations; e.g. regulated products
-- (Jon) Reverted the `unit_tests.yml` file to ensure the test accepts higher ruby
-versions and allows it to work with current app integrations; e.g. regulated products
+- (Jon) Reverted the `gemspec` file to ensure the gem accepts higher ruby
+versions and allows it to work with current app integrations; e.g. regulated
+products
+- (Jon) Reverted the `unit_tests.yml` file to ensure the test accepts higher
+ruby versions and allows it to work with current app integrations; e.g.
+regulated products
 
 ## 0.3.5.4 - 2023-03-24
 
-- (Jon) Removed the rails specific properties from the JSON output as they are not
-  required by the logging monitors and consume more disk space than desired.
+- (Jon) Removed the rails specific properties from the JSON output as they are
+  not required by the logging monitors and consume more disk space than desired.
 - (Jon) Reordered the Timestamp and Level properties to match the order of other
   logs on the Epimorphics system tooling.
 
 ## 0.3.5.3 - 2023-03-10
 
 - (Jon) Added .ruby-version file to ensure the gem is locked to the specific
-  2.6.6 ruby version to reduce any potential issues with current app integrations
+  2.6.6 ruby version to reduce any potential issues with current app
+  integrations
 - (Jon) Updated the gemspec to ensure the gem is locked to the same 2.6.6 ruby
   version to reduce any potential issues with current app integrations
 - (Jon) Removed dependency version locks due to connected apps not supporting
@@ -27,8 +37,8 @@ versions and allows it to work with current app integrations; e.g. regulated pro
 
 - (Jon) Updated the gemspec to ensure the dependency versions are locked to
   specific base versions to avoid any potential issues with the gem being used
-- (Jon) Added specific versions to the gemspec dependencies to resolve open-ended
-  dependency warnings when publishing the gem.
+- (Jon) Added specific versions to the gemspec dependencies to resolve
+  open-ended dependency warnings when publishing the gem.
 
 ## 0.3.5.1 - 2023-01-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog for the JSON Rails Logger gem
 
-## 0.3.6.0 - 2023-05-24
+## 0.3.6.0 - 2023-06-01
 
-- (Jon) After determining the request_id variable was not always being filled in
-  via the `env['HTTP_X_REQUEST_ID']` request,  the rails environment variable
-  `env['action_dispatch.request_id']` was re-added to ensure this value was
-  collected and parsed.
+- (Jon) Now uses the `env['action_dispatch.request_id']` variable ONLY in the
+development environment in order to mimic the `HTTP_X_REQUEST_ID` header as that
+header doesn't exist when running rails server in the development environment.
+- (Jon) Reports on `GET, POST, PUT, DELETE, PATCH` request methods instead of
+only `GET`
 
 ## 0.3.5.5 - 2023-05-10
 

--- a/lib/json_rails_logger/constants.rb
+++ b/lib/json_rails_logger/constants.rb
@@ -2,4 +2,34 @@
 
 module JsonRailsLogger
   REQUEST_ID = :request_id
+  # * THE FOLLOWING ARE NOT CURRENTLY USED BUT AVAILABLE FOR FUTURE USE * #
+  # REQUEST_URI = :request_uri
+  # REQUEST_METHOD = :request_method
+  # REQUEST_PATH = :request_path
+  # SERVER_NAME = :server_name
+  # STATUS = :status
+  # DURATION = :duration
+  # USER_AGENT = :user_agent
+  # ACCEPT = :accept
+  # MESSAGE = :message
+  # EXCEPTION = :exception
+  # BACKTRACE = :backtrace
+  # CONTROLLER = :controller
+  # ACTION = :action
+  # PARAMS = :params
+  # IP = :ip
+  # AUTH = :auth
+  # HTTP_HOST = :http_host
+  # HTTP_VERSION = :http_version
+  # HTTP_REFERER = :http_referer
+  # HTTP_COOKIE = :http_cookie
+  # HTTP_ACCEPT_ENCODING = :http_accept_encoding
+  # HTTP_ACCEPT_LANGUAGE = :http_accept_language
+  # HTTP_ACCEPT_CHARSET = :http_accept_charset
+  # HTTP_CACHE_CONTROL = :http_cache_control
+  # HTTP_CONNECTION = :http_connection
+  # HTTP_UPGRADE_INSECURE_REQUESTS = :http_upgrade_insecure_requests
+  # HTTP_ORIGIN = :http_origin
+  # HTTP_DNT = :http_dnt
+  # HTTP_X_REQUEST_ID = :http_x_request_id
 end

--- a/lib/json_rails_logger/json_formatter.rb
+++ b/lib/json_rails_logger/json_formatter.rb
@@ -13,8 +13,10 @@ module JsonRailsLogger
       msg = process_message(raw_msg)
       new_msg = format_message(msg)
 
-      payload = { ts: timestp,
-                  level: sev}
+      payload = {
+        ts: timestp,
+        level: sev
+      }
 
       payload.merge!(request_id.to_h)
       payload.merge!(new_msg.to_h)

--- a/lib/json_rails_logger/json_formatter.rb
+++ b/lib/json_rails_logger/json_formatter.rb
@@ -7,6 +7,8 @@ module JsonRailsLogger
       method path status duration user_agent accept request_id
     ].freeze
 
+    REQUEST_METHODS = %w[GET, POST, PUT, DELETE, PATCH].freeze
+
     def call(severity, timestamp, _progname, raw_msg)
       sev = process_severity(severity)
       timestp = process_timestamp(timestamp)
@@ -45,7 +47,7 @@ module JsonRailsLogger
       return msg unless msg.is_a?(String)
 
       return status_message(msg) if status_message?(msg)
-      return get_message(msg) if get_message?(msg)
+      return request_type(msg) if request_type?(msg)
       return user_agent_message(msg) if user_agent_message?(msg)
 
       { message: msg.squish }
@@ -95,12 +97,12 @@ module JsonRailsLogger
       { status: status }
     end
 
-    def get_message?(msg)
+    def request_type?(msg)
       msg.is_a?(String) &&
-        msg.match(/GET http\S+/)
+        REQUEST_METHODS.any? { |method| msg.match(/#{method} http\S+/) }
     end
 
-    def get_message(msg)
+    def request_type(msg)
       splitted_msg = msg.split
       method = splitted_msg[0]
       path = splitted_msg[1]

--- a/lib/json_rails_logger/json_formatter.rb
+++ b/lib/json_rails_logger/json_formatter.rb
@@ -7,7 +7,7 @@ module JsonRailsLogger
       method path status duration user_agent accept request_id
     ].freeze
 
-    REQUEST_METHODS = %w[GET, POST, PUT, DELETE, PATCH].freeze
+    REQUEST_METHODS = %w[GET POST PUT DELETE PATCH].freeze
 
     def call(severity, timestamp, _progname, raw_msg)
       sev = process_severity(severity)
@@ -45,7 +45,6 @@ module JsonRailsLogger
       msg = normalize_message(raw_msg)
 
       return msg unless msg.is_a?(String)
-
       return status_message(msg) if status_message?(msg)
       return request_type(msg) if request_type?(msg)
       return user_agent_message(msg) if user_agent_message?(msg)
@@ -106,7 +105,6 @@ module JsonRailsLogger
       splitted_msg = msg.split
       method = splitted_msg[0]
       path = splitted_msg[1]
-
       { method: method, path: path }
     end
 

--- a/lib/json_rails_logger/request_id_middleware.rb
+++ b/lib/json_rails_logger/request_id_middleware.rb
@@ -9,7 +9,8 @@ module JsonRailsLogger
     end
 
     def call(env)
-      request_id = env['HTTP_X_REQUEST_ID'] || env['action_dispatch.request_id']
+      request_id = env['HTTP_X_REQUEST_ID']
+      request_id = env['action_dispatch.request_id'] if Rails.env.development?
       Thread.current[JsonRailsLogger::REQUEST_ID] = request_id
       @app.call(env)
     ensure

--- a/lib/json_rails_logger/request_id_middleware.rb
+++ b/lib/json_rails_logger/request_id_middleware.rb
@@ -9,7 +9,7 @@ module JsonRailsLogger
     end
 
     def call(env)
-      request_id = env['HTTP_X_REQUEST_ID']
+      request_id = env['HTTP_X_REQUEST_ID'] || env['action_dispatch.request_id']
       Thread.current[JsonRailsLogger::REQUEST_ID] = request_id
       @app.call(env)
     ensure

--- a/lib/json_rails_logger/version.rb
+++ b/lib/json_rails_logger/version.rb
@@ -3,7 +3,7 @@
 module JsonRailsLogger
   MAJOR = 0
   MINOR = 3
-  PATCH = 5
-  SUFFIX = 5
+  PATCH = 6
+  SUFFIX = 0
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && '.' + SUFFIX.to_s}"
 end


### PR DESCRIPTION
After determining the request_id variable was not always being filled in via the `env['HTTP_X_REQUEST_ID']` request,  the rails environment variable `env['action_dispatch.request_id']` was re-added as a fallback to ensure this value was collected and parsed.