### PR TITLE
Updated Parameter Naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for the JSON Rails Logger gem
 
+## 1.0.2 - 2023-06-21
+
+- (Jon) Renamed parameter to reduce chance of conflict with other gems or code
+  that may use the same parameter name.
+
 ## 1.0.1 - 2023-06-07
 
 - (Jon) Updated the logging to include additional properties to ensure the

--- a/lib/json_rails_logger/json_formatter.rb
+++ b/lib/json_rails_logger/json_formatter.rb
@@ -5,7 +5,7 @@ module JsonRailsLogger
   class JsonFormatter < ::Logger::Formatter
     ## Required keys to be logged to the output
     REQUIRED_KEYS = %w[
-      method path status duration user_agent accept request_id url message
+      method path status duration user_agent accept request_id request_url message
     ].freeze
 
     ## Optional keys to be ignored from the output for the time being
@@ -30,6 +30,7 @@ module JsonRailsLogger
       payload.merge!(new_msg.to_h.except!(:optional).compact)
 
       "#{payload.to_json}\n"
+      "\n#{payload.to_json}\n" if Rails.env.development?
     end
     # rubocop:enable Metrics/MethodLength
 

--- a/lib/json_rails_logger/json_formatter.rb
+++ b/lib/json_rails_logger/json_formatter.rb
@@ -29,8 +29,9 @@ module JsonRailsLogger
       payload.merge!(request_id.to_h)
       payload.merge!(new_msg.to_h.except!(:optional).compact)
 
-      "#{payload.to_json}\n"
       "\n#{payload.to_json}\n" if Rails.env.development?
+
+      "#{payload.to_json}\n"
     end
     # rubocop:enable Metrics/MethodLength
 

--- a/lib/json_rails_logger/version.rb
+++ b/lib/json_rails_logger/version.rb
@@ -3,7 +3,7 @@
 module JsonRailsLogger
   MAJOR = 1
   MINOR = 0
-  PATCH = 1
+  PATCH = 2
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}"
 end


### PR DESCRIPTION
In our continued effort to improve the logging handled by the applications this change resolves the logger mechanism to recognise the renamed parameter passed from the data-services-api gem.