### PR TITLE
Updated Publish Action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,29 +1,42 @@
-name: Publish to GPR
+name: Release and Publish Gem
 on:
   workflow_dispatch: {}
-  push:
-    branches:
-      - main
 
 #---- Below this line should not require editing ----
 jobs:
-  publish:
-    name: "Publish: ECR Image Upload"
-    runs-on: ubuntu-20.04
-    outputs:
-      image: ${{ steps.mapper.outputs.image }}
-      tag: ${{ steps.gitinfo.outputs.tag }}
-      target: ${{ steps.mapper.outputs.target }}
-
+  build:
+    name: "Build gem package"
+    runs-on: ubuntu-latest
     steps:
-    - name: "Checkout"
-      uses: actions/checkout@v2
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
-    - name: "Publish image"
-      if: steps.mapper.outputs.image != ''
-      env:
-        IMAGE: ${{ steps.mapper.outputs.image }}
-        TAG: ${{ steps.gitinfo.outputs.tag }}
-      shell: bash
+    - name: "Git Information"
+      id: gitinfo
       run: |
-        PAT=${{ secrets.EPI_GPR_ACCESS_TOKEN }} make publish
+        echo name=${GITHUB_REF#refs/*/}       | tee -a $GITHUB_OUTPUT
+        echo branch=${GITHUB_REF#refs/heads/} | tee -a $GITHUB_OUTPUT
+        make tags                             | tee -a $GITHUB_OUTPUT
+
+    - name: "Build gem"
+      run: "make gem"
+
+    - name: "Create Release"
+      id: release
+      uses: softprops/action-gh-release@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ steps.gitinfo.outputs.version }}
+        name: v${{ steps.gitinfo.outputs.version }}
+        generate_release_notes: true
+        draft: false
+        prerelease: false
+        files: |
+          json_rails_logger-${{ steps.gitinfo.outputs.version }}.gem
+
+    - name: "Publish gem"
+      run: |
+        PAT=${{ secrets.GITHUB_TOKEN }} make publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog for the JSON Rails Logger gem
 
+## 1.0.4-rc01 - 2023-08
+
+- (Jon) Updated the GitHub action to reflect the revised company's gem
+  publishing strategy
+- (Jon) Removed the push trigger as gem creation needs to be a manual process
+- (Jon) Reorganised and removed duplicated makefile targets
+- (Jon) Introduces the use of the `${NAME}` variable to increase portability of
+  the revised makefile approach
+
 ## 1.0.3 - 2023-06-23
 
 - (Jon) For continued improvements to the logs, additional keys need to be added

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 NAME?=json_rails_logger
 OWNER?=epimorphics
-VERSION?=$(shell ruby -e 'require "./lib/json_rails_logger/version" ; puts JsonRailsLogger::VERSION')
+VERSION?=$(shell ruby -e 'require "./lib/${NAME}/version" ; puts JsonRailsLogger::VERSION')
 PAT?=$(shell read -p 'Github access token:' TOKEN; echo $$TOKEN)
 
 AUTH=${HOME}/.gem/credentials
@@ -12,18 +12,18 @@ SPEC=${NAME}.gemspec
 
 all: publish
 
+auth: ${AUTH}
+
+build: gem
+
 ${AUTH}:
 	@mkdir -p ${HOME}/.gem
 	@echo '---' > ${AUTH}
 	@echo ':github: Bearer ${PAT}' >> ${AUTH}
 	@chmod 0600 ${AUTH}
 
-${GEM}: ${SPEC} ./lib/json_rails_logger/version.rb
+${GEM}: ${SPEC} ./lib/${NAME}/version.rb
 	gem build ${SPEC}
-
-auth: ${AUTH}
-
-build: gem
 
 gem: ${GEM}
 	@echo ${GEM}
@@ -32,13 +32,16 @@ test: gem
 	@bundle install
 	@rake test
 
-publish: ${GEM}
+publish: ${AUTH} ${GEM}
 	@echo Publishing package ${NAME}:${VERSION} to ${OWNER} ...
 	@gem push --key github --host ${GPR} ${GEM}
 	@echo Done.
 
 clean:
-	@rm -rf ${GEM} 
+	@rm -rf ${GEM}
 
 realclean: clean
-	@rm -rf ${AUTH} 
+	@rm -rf ${AUTH}
+
+tags:
+	@echo version=${VERSION}

--- a/json_rails_logger.gemspec
+++ b/json_rails_logger.gemspec
@@ -27,9 +27,9 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'json'
-  spec.add_runtime_dependency 'lograge'
-  spec.add_runtime_dependency 'railties'
+  spec.add_runtime_dependency 'json', '~> 2.0'
+  spec.add_runtime_dependency 'lograge', '~> 0.11'
+  spec.add_runtime_dependency 'railties', '~> 6.0'
 
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake', '~> 13.0'
 end

--- a/lib/json_rails_logger/version.rb
+++ b/lib/json_rails_logger/version.rb
@@ -3,7 +3,7 @@
 module JsonRailsLogger
   MAJOR = 1
   MINOR = 0
-  PATCH = 3
-  SUFFIX = nil
-  VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}"
+  PATCH = 4
+  SUFFIX = 'rc01'
+  VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && "-#{SUFFIX}"}"
 end


### PR DESCRIPTION
- Updated the GitHub action to reflect the revised company's gem publishing strategy
- Removed the push trigger as gem creation needs to be a manual process
- Reorganised and removed duplicated makefile targets
- Introduces the use of the `${NAME}` variable to increase portability of the revised makefile approach

**N.B. This is marked as a release candidate in the version cadence as there is additional work needed to define a gem naming standard, port to it, and make stuff common across all public and private gems; not to mention then having to initiate releases on all applications which use this, and any other, gem that needs updated.**