### PR TITLE
Spike: Request Time format update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog for the JSON Rails Logger gem
 
-## 2.0.3 - 2025-02
+## 2.0.3 - 2025-03
 
+- (Jon) Enhance logging with request time formatting
+  - Added conditional check for request time presence
+  - Improved request time format to include seconds and milliseconds
+  - Updated log message structure for clarity
 - (Jon) Added pre-commit and pre-push hooks to the gem to ensure the code is
   linted and tested before being committed or pushed to the repository.
 - (Jon) Added detailed logging for completed actions, including the action name,

--- a/lib/json_rails_logger/json_formatter.rb
+++ b/lib/json_rails_logger/json_formatter.rb
@@ -57,7 +57,7 @@ module JsonRailsLogger
     REQUEST_METHODS = %w[GET POST PUT DELETE PATCH].freeze
 
     # rubocop:disable Metrics/MethodLength
-    def call(severity, timestamp, _progname, raw_msg) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
+    def call(severity, timestamp, _progname, raw_msg) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       sev = process_severity(severity)
       timestp = process_timestamp(timestamp)
       msg = process_message(raw_msg)
@@ -84,7 +84,11 @@ module JsonRailsLogger
       if new_msg[:optional].present? && new_msg[:optional].respond_to?(:[])
         message = "Completed#{format(' %s', new_msg[:optional]['action'])} action"
         message += " for #{new_msg[:optional]['controller']}"
-        message += format(', time taken: %.0f ms', new_msg[:request_time])
+        if new_msg[:request_time].present?
+          message += format(', time taken: %.0f ms', new_msg[:request_time])
+          seconds, milliseconds = new_msg[:request_time].divmod(1000)
+          new_msg[:request_time] = format('%.0f.%04d', seconds, milliseconds) # rubocop:disable Style/FormatStringToken
+        end
         new_msg[:message] = message
         new_msg[:request_status] = 'completed' if new_msg[:request_status].nil?
         payload[:level] = 'DEBUG'


### PR DESCRIPTION
This PR primarily changes the format of the reported request time property to show as seconds, this means there will be a leading zero and four decimal places, but displayed as a string, not an integer.

_N.B. This will be released to replace the current gem version as this is a continuation of the initial version changes based on internal discussions._