### PR TITLE
Task: Release v2.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog for the JSON Rails Logger gem
 
+## 2.0.5 - 2025-04
+
+- (Jon) Added a new method `remove_unprintable_characters` to filter out
+  unprintable and non-ASCII characters from log messages.
+- (Jon) Updated the `call` method to include the new `remove_unprintable_characters`
+  method, ensuring that log messages are cleaned before being logged.
+
 ## 2.0.4 - 2025-04
 
 - (Jon) Extracted the optional messages and `request_time` formatting logic to

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    json_rails_logger (2.0.4)
+    json_rails_logger (2.0.5)
       json
       lograge
       railties

--- a/lib/json_rails_logger/json_formatter.rb
+++ b/lib/json_rails_logger/json_formatter.rb
@@ -13,6 +13,7 @@ module JsonRailsLogger
       method
       path
       query_string
+      returned_rows
       request_id
       request_params
       request_path

--- a/lib/json_rails_logger/json_formatter.rb
+++ b/lib/json_rails_logger/json_formatter.rb
@@ -138,11 +138,25 @@ module JsonRailsLogger
       return request_type(msg) if request_type?(msg)
       return user_agent_message(msg) if user_agent_message?(msg)
 
+      # Clean up the message if it contains special characters
+      msg = remove_unprintable_characters(msg)
+
       # squish is better than strip as it still returns the string, but first
       # removing all whitespace on both ends of the string, and then changing
       # remaining consecutive whitespace groups into one space each. strip only
       # removes white spaces only at the leading and trailing ends.
       { message: msg.squish }
+    end
+
+    def remove_unprintable_characters(msg)
+      # Remove ANSI escape codes
+      msg = msg.gsub(/\e\[[0-9;]*m/, '') if msg.match?(/\e\[[0-9;]*m/)
+      # Remove all non-printable characters
+      msg = msg.gsub(/[^[:print:]]/, '') if msg.match?(/[^[:print:]]/)
+      # Remove all non-ASCII characters
+      msg = msg.gsub(/[^\x00-\x7F]/, '') if msg.match?(/[^\x00-\x7F]/)
+
+      msg
     end
 
     def process_optional_messages(msg) # rubocop:disable Metrics/AbcSize

--- a/lib/json_rails_logger/version.rb
+++ b/lib/json_rails_logger/version.rb
@@ -3,7 +3,7 @@
 module JsonRailsLogger
   MAJOR = 2
   MINOR = 0
-  PATCH = 4
+  PATCH = 5
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && "-#{SUFFIX}"}".freeze
 end


### PR DESCRIPTION
Sanitises log messages to remove non printable characters. Adds a method to strip non printable and non-ASCII characters from log messages. The logging pipeline is updated to call this sanitisation method.

## Changes

- Adds the `remove_unprintable_characters` method to sanitise log messages by removing ANSI escape codes, non-printable characters, and non-ASCII characters.
- Updates the logging pipeline to include the new `remove_unprintable_characters` method before squishing the message.
- Updates the gem version from 2.0.4 to 2.0.5 in the gemfile and version file.
- Updates the changelog to document the new feature and version bump.

## Impact

- Log messages will now be sanitised to remove potentially problematic characters, improving log readability and compatibility with various systems.