### PR TITLE
Task: Release v2.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog for the JSON Rails Logger gem
 
+## 2.0.5 - 2025-04
+
+- (Jon) Added a new method `remove_unprintable_characters` to filter out
+  unprintable and non-ASCII characters from log messages.
+- (Jon) Updated the `call` method to include the new `remove_unprintable_characters`
+  method, ensuring that log messages are cleaned before being logged.
+
 ## 2.0.4 - 2025-04
 
 - (Jon) Extracted the optional messages and `request_time` formatting logic to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,24 @@
 # Changelog for the JSON Rails Logger gem
 
+## 2.0.6 - 2025-05
+
+- (Jon) Improves severity level processing by mapping numeric and string levels to standard values.
+- (Jon) Processes the program name and removes trailing spaces for valid JSON.
+- (Jon) Handles nil messages gracefully to prevent errors.
+- (Jon) Standardises Webpacker log level to DEBUG for filtering.
+- (Jon) Suppresses colourised output and original logs.
+- (Jon) Updates timestamp variable name for clarity.
+- (Jon) Adds progname to the logged message.
+- (Jon) Left-justifies the log level in the payload.
+- (Jon) Documents how to configure the custom JSON formatter.
+
 ## 2.0.5 - 2025-04
 
 - (Jon) Added a new method `remove_unprintable_characters` to filter out
   unprintable and non-ASCII characters from log messages.
-- (Jon) Updated the `call` method to include the new `remove_unprintable_characters`
-  method, ensuring that log messages are cleaned before being logged.
+- (Jon) Updated the `call` method to include the new
+  `remove_unprintable_characters` method, ensuring that log messages are cleaned
+  before being logged.
 
 ## 2.0.4 - 2025-04
 
@@ -17,8 +30,8 @@
   method, ensuring that the optional messages are processed correctly.
 - (Jon) Separated the request time formatting into its own block to improve
   readability and maintainability.
-- (Jon) Updated .rubocop.yml to ignore long comments to reduce noise in the CI/CD
-  pipeline
+- (Jon) Updated .rubocop.yml to ignore long comments to reduce noise in the
+  CI/CD pipeline
 
 ## 2.0.3 - 2025-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 2.0.6 - 2025-05
 
-- (Jon) Improves severity level processing by mapping numeric and string levels to standard values.
+- (Jon) Improves severity level processing by mapping numeric and string levels
+  to standard values.
 - (Jon) Processes the program name and removes trailing spaces for valid JSON.
 - (Jon) Handles nil messages gracefully to prevent errors.
 - (Jon) Standardises Webpacker log level to DEBUG for filtering.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    json_rails_logger (2.0.5)
+    json_rails_logger (2.0.6)
       json
       lograge
       railties

--- a/lib/json_rails_logger/json_formatter.rb
+++ b/lib/json_rails_logger/json_formatter.rb
@@ -77,8 +77,11 @@ module JsonRailsLogger
       }
 
       # ! SET THIS MESSAGE FROM WEBPACKER TO DEBUG LIKE THE DEVELOPERS SHOULD HAVE!
+      # ! NOTE: This message may still be present in production due to the logging
+      # ! level not actually being set to debug but can still be filtered out
+      # ! by the elastic search filters
       if new_msg[:message] == "[Webpacker] Everything's up-to-date. Nothing to do"
-        payload[:level] = 'DEBUG'
+        payload[:level] = process_severity(Logger::DEBUG)
       end
 
       # ! SET THIS MESSAGE FROM RAILS TO DEBUG AS IT CONTAINS ONLY BASE INFORMATION!

--- a/lib/json_rails_logger/json_formatter.rb
+++ b/lib/json_rails_logger/json_formatter.rb
@@ -68,14 +68,14 @@ module JsonRailsLogger
 
       # * Uncomment to print out the raw, processed and formatted messages to the console
       # if Rails.logger.debug?
-      #   puts "\n\e[41m> received raw_msg: #{raw_msg}\e[0m"
-      #   puts "\e[32m> processed msg: #{msg}\e[0m"
-      #   puts "\e[33m> formatted new msg: #{new_msg}\e[0m\n\n"
+      #   puts "\n\e[41m> received #{severity} raw_msg at #{tmstmp}: #{raw_msg}\e[0m"
+      #   puts "\e[32m> processed #{severity} msg at #{tmstmp}: #{msg}\e[0m"
+      #   puts "\e[33m> formatted #{severity} new msg at #{tmstmp}: #{new_msg}\e[0m\n\n"
       # end
 
       payload = {
         ts: tmstmp,
-        level: sev
+        level: sev.ljust(5)
       }
 
       # ! SET THIS MESSAGE FROM WEBPACKER TO DEBUG LIKE THE DEVELOPERS SHOULD HAVE!
@@ -90,7 +90,6 @@ module JsonRailsLogger
       if new_msg[:optional].present? && new_msg[:optional].respond_to?(:[])
         new_msg[:message] = process_optional_messages(new_msg)
         new_msg[:request_status] = 'completed' if new_msg[:request_status].nil?
-        payload[:level] = 'DEBUG'
       end
 
       # * Add the request time to the message if it is present and does not already contain it

--- a/lib/json_rails_logger/json_formatter.rb
+++ b/lib/json_rails_logger/json_formatter.rb
@@ -107,7 +107,14 @@ module JsonRailsLogger
     private
 
     def process_severity(severity)
-      { 'FATAL' => 'ERROR' }[severity] || severity
+      case severity
+      when 0, 'DEBUG', 'TRACE' then 'DEBUG'
+      when 1, 'INFO' then 'INFO'
+      when 2, 'WARN' then 'WARN'
+      when 3, 'ANY', 'UNKNOWN', 'CRITICAL', 'FATAL', 'ERROR' then 'ERROR'
+      else
+        severity
+      end
     end
 
     def process_timestamp(timestamp)

--- a/lib/json_rails_logger/json_formatter.rb
+++ b/lib/json_rails_logger/json_formatter.rb
@@ -60,7 +60,7 @@ module JsonRailsLogger
     # rubocop:disable Metrics/MethodLength
     def call(severity, timestamp, progname, raw_msg) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       sev = process_severity(severity)
-      timestp = process_timestamp(timestamp)
+      tmstmp = process_timestamp(timestamp)
       prgname = process_progname(progname)
       msg = process_message(raw_msg)
       msg[:progname] = prgname if prgname
@@ -74,7 +74,7 @@ module JsonRailsLogger
       # end
 
       payload = {
-        ts: timestp,
+        ts: tmstmp,
         level: sev
       }
 

--- a/lib/json_rails_logger/json_formatter.rb
+++ b/lib/json_rails_logger/json_formatter.rb
@@ -159,6 +159,10 @@ module JsonRailsLogger
     end
 
     def process_message(raw_msg)
+      # If the message is nil, return an empty hash
+      return {} if raw_msg.nil?
+
+      # Otherwise, normalize the message
       msg = normalize_message(raw_msg)
 
       return msg unless msg.is_a?(String)

--- a/lib/json_rails_logger/logger.rb
+++ b/lib/json_rails_logger/logger.rb
@@ -9,10 +9,13 @@ module JsonRailsLogger
     #
     # +logdev+ The output device to send log messages to
     def initialize(logdev)
+      # Set up the formatter to use our custom JSON formatter
       formatter = JsonRailsLogger::JsonFormatter.new
+      # and set the datetime format to ISO 8601 with milliseconds and UTC timezone
       formatter.datetime_format = '%Y-%m-%dT%H:%M:%S.%3NZ'
-
+      # Call the parent constructor with the logdev and formatter
       super(logdev, formatter: formatter)
+      # Set the formatter to our custom JSON formatter
       @formatter = formatter
     end
   end

--- a/lib/json_rails_logger/railtie.rb
+++ b/lib/json_rails_logger/railtie.rb
@@ -3,6 +3,8 @@
 module JsonRailsLogger
   # This class is used to configure and setup lograge, as well as our gem
   class Railtie < Rails::Railtie
+    config.colorize_logging = false
+    config.lograge.keep_original_rails_log = false
     config.lograge.formatter = Lograge::Formatters::Json.new
     config.lograge.custom_options = lambda do |event|
       {

--- a/lib/json_rails_logger/version.rb
+++ b/lib/json_rails_logger/version.rb
@@ -3,7 +3,7 @@
 module JsonRailsLogger
   MAJOR = 2
   MINOR = 0
-  PATCH = 5
+  PATCH = 6
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && "-#{SUFFIX}"}".freeze
 end


### PR DESCRIPTION
This PR refactors the JSON logger to improve debug logging, standardise severity levels, remove trailing spaces from program names, and handle nil messages. It also suppresses colourised output and original logs.

## Changes

- Improves severity level processing, mapping numeric and string levels to standard values (`DEBUG`, `INFO`, `WARN`, `ERROR`).
- Adds functionality to process the program name (`progname`) and remove any trailing spaces to avoid JSON formatting issues.
- Handles `nil` messages by returning an empty hash, preventing errors.
- Standardises the Webpacker log level to DEBUG for additional filtering.
- Suppresses colourised output and original logs by setting `config.colorize_logging = false` and `config.lograge.keep_original_rails_log = false`.
- Updates the timestamp variable name for clarity and consistency.
- Modifies the debug logging output to include severity and timestamp information.
- Adds progname to the logged message if it exists.
- Left-justifies the log level in the payload with a length of 5.
- Explains how the formatter is set to use the custom JSON formatter, the datetime format to ISO 8601 with milliseconds and UTC timezone, and apply the configuration.

## Impact

- Log messages will have consistent severity levels.
- Log messages will no longer have trailing spaces in the progname.
- Debug logging is improved with the addition of severity and timestamp information, improving readability and debugging.
- Errors due to nil messages are prevented.
- Colourised logging is disabled in the rails application.
- Original logs are now suppressed