### PR TITLE
Spike: Handover-resolution

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,6 +1,15 @@
 name: Unit Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+      # Add your branch naming conventions here, e.g. 'feature/**', 'fix/**'
+      # Restricting push to specific branches prevents duplicate runs when a PR
+      # is open — without this, both push and pull_request fire on every commit.
+  pull_request:
+    branches:
+      - main
 
 jobs:
   test:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,9 +4,8 @@ on:
   push:
     branches:
       - main
-      # Add your branch naming conventions here, e.g. 'feature/**', 'fix/**'
       # Restricting push to specific branches prevents duplicate runs when a PR
-      # is open — without this, both push and pull_request fire on every commit.
+      # is open - without this, both push and pull_request fire on every commit.
   pull_request:
     branches:
       - main
@@ -36,5 +35,8 @@ jobs:
         run: bundle install
 
       - name: Run checks
-        run: |
-          PAT=${{ secrets.EPI_GPR_READ_ACCESS_TOKEN }} make lint test
+        # Passing the token via env rather than interpolating it directly into
+        # the run string prevents it from appearing in logs or process listings.
+        env:
+          PAT: ${{ secrets.EPI_GPR_READ_ACCESS_TOKEN }}
+        run: make lint test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,38 @@
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic
-Versioning](https://semver.org/spec/v2.0.0.html).
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## [3.0.1] - 2026-04
+
+### Fixed
+
+- `request_time` is now emitted as a floating-point number (e.g. `1.094`) rather
+  than a string (e.g. `"1.094"`), correcting a type inconsistency with the
+  [Epimorphics Logging Standard](https://github.com/epimorphics/internal/wiki/Logging-Standard#additional-fields)
+  which requires consistent numeric types for fields consumed by the logging
+  stack.
+- `message` is now omitted from log output entirely when no message value is
+  present (e.g. structured-only Faraday client log entries), rather than being
+  emitted as `null`. The logging standard requires fields to appear only when
+  pertinent.
+
+### Changed
+
+- Makefile rewritten to reflect gem development workflow. Application-specific
+  targets have been removed, missing targets (`gem`, `tags`, `docs`) added, and
+  broken targets (`VERSION` path, `test`, `lint`, `publish`) corrected. The
+  `gem` and `tags` targets are required by the CI publication workflow. All
+  targets are alphabetically ordered.
+- CONTRIBUTING.md updated to correct the setup command, reflect current
+  Makefile targets, fix a stale authentication reference, and clarify the
+  publication process.
+- README.md restructured for faster reference during incidents, with output format
+  and severity levels moved to the top. Real log examples, a common fields
+  table, Puma configuration guidance, and version requirements added. The
+  upgrading section correctly distinguishes v2.x from v2.3.0 changes.
 
 ## [3.0.0] - 2026-03
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,10 +9,10 @@ After cloning the repository:
 ### Install Dependencies
 
 ```sh
-make assets
+make bundles
 ```
 
-This installs all required gems and dependencies.
+This installs all required gems via Bundler.
 
 ### GitHub Package Registry Authentication
 
@@ -39,28 +39,33 @@ access token.
 
 #### For Developers (Working on the Gem)
 
-By convention, there is a convenient `Makefile` target to help developers store
-the PAT and authorise Bundler:
+By convention, there is a convenient `Makefile` target to help developers
+authenticate with the GitHub Package Registry. Running `make auth` will prompt
+for your PAT and write it to `~/.gem/credentials`:[^‡]
 
 ```sh
 make auth
 ```
 
-When run for the first time, this will prompt for your PAT.[^‡]
+The same mechanism is used by the CI publication workflow, where the PAT is
+supplied automatically via `secrets.GITHUB_TOKEN`.
 
 ## Development Workflow
 
 ### `Makefile` Commands
 
-The project includes a `Makefile` with other common development tasks:
+The project includes a `Makefile` with common development tasks:
 
-- `make build` — Check that the gem builds correctly
 - `make auth` — Create GitHub and Bundler authorisations
-- `make test` — Run the test suite
-- `make lint` — Run Rubocop linting
+- `make build` — Build the gem locally
 - `make check` — Run both linting and tests
-- `make doc` — Generate YARD documentation
-- `make publish` — Publish the gem to GitHub package registry
+- `make docs` — Generate YARD documentation and open in browser
+- `make gem` — Build the gem package for release
+- `make lint` — Run Rubocop linting
+- `make publish` — Build and publish the gem to the GitHub Package Registry
+- `make tags` — Display version information for the CI pipeline
+- `make test` — Run the test suite
+- `make updates` — Check for outdated Ruby gems
 
 ## API Documentation
 
@@ -86,13 +91,12 @@ To publish a new version of the gem after a bugfix or feature addition:
 2. Update the `CHANGELOG.md` to document the new change
 3. `git tag` the new state with a tag that matches the new version
 4. Push the new tagged release to GitHub
-5. Run `make publish` to push the new gem to the GitHub package registry
 
 Pushing a tagged version will automatically trigger the publish gem workflow,
 which should result in the gem appearing on the [list of
-releases](https://github.com/epimorphics/json-rails-logger/releases).
+releases](https://github.com/epimorphics/json-rails-logger/releases). If the
+workflow does not trigger or needs to be run manually, `make publish` will build
+and push the gem directly to the GitHub Package Registry.
 
-[^‡]: See [notes on the
-Epimorphics internal
-wiki](https://github.com/epimorphics/internal/wiki/Ansible-CICD#creating-a-pat-for-gpr-access)
+[^‡]: See [notes on the Epimorphics internal wiki](https://github.com/epimorphics/internal/wiki/Ansible-CICD#creating-a-pat-for-gpr-access)
 about creating a PAT.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    json_rails_logger (3.0.0)
+    json_rails_logger (3.0.1)
       json (>= 1.8, < 5.0)
       lograge (>= 0.10, < 2.0)
       railties (>= 6.0, < 9.0)

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
-.PHONY: all assets auth build bundles check checks clean coverage doc gem help lint publish realclean rubocop tags test update vars
+.PHONY: all auth build bundles check checks clean coverage docs forceclean gem help lint publish realclean rubocop tag tags test updates vars version
 
 NAME?=json_rails_logger
 OWNER?=epimorphics
+COMMIT=$(shell git rev-parse --short HEAD)
 VERSION?=$(shell /usr/bin/env ruby -e 'require "./lib/${NAME}/version" ; puts JsonRailsLogger::VERSION')
+TAG?=${VERSION}-${COMMIT}
 PAT?=$(shell read -p 'Github access token:' TOKEN; echo $$TOKEN)
 BUNDLE?=bundle
 
@@ -21,91 +23,90 @@ ${AUTH}:
 ${GEM}: ${SPEC} ./lib/${NAME}/version.rb
 	gem build ${SPEC}
 
-all: publish ## Default target: publish the gem
+all: check ## Default target: run all checks
 
-assets: auth bundles ## Build assets for gem package
-	@echo assets completed.
+auth: ${AUTH} ## Set up authentication for GitHub and Bundler
+	@echo "Authentication set up for GitHub and Bundler."
 
-auth: ${AUTH} ## Set up authentication for package distribution
-	@echo "Authentication set up for package distribution."
+build: ## Build the gem
+	@echo "Building ${GEM} ..."
+	@${BUNDLE} exec gem build ${SPEC}
+	@echo "Done."
 
-build: clean gem ## Build the gem package
-
-bundles: ## Install gem dependencies via Bundler
-	@echo "Installing gem dependencies via Bundler..."
+bundles: ## Install Ruby gems via Bundler
+	@echo "Installing Ruby gems via Bundler..."
 	@${BUNDLE} install
 
-check: checks ## Alias for `checks` target
+check: checks ## Alias for checks target
 
 checks: lint test ## Run all checks: linting and tests
 	@echo "All checks passed."
 
-clean: ## Clean up generated gem package
-	@echo "Removing ${GEM} ..."
-	@rm -rf ${GEM}
+clean: ## Remove generated files
+	@echo "Cleaning up..."
+	@rm -rf coverage doc *.gem
 
 coverage: ## Display test coverage report
 	@open coverage/index.html
 	@echo "Displaying test coverage report in browser..."
 
-doc: ## Generate YARD API documentation
-	@yard doc
+docs: ## Generate YARD documentation and open in browser
+	@echo "Generating YARD documentation..."
+	@${BUNDLE} exec yard doc
 	@open doc/index.html
-	@echo "Displaying API documentation generated in doc/index.html"
-	@echo "Available in IDE autocompletion (hover over methods in VS Code/RubyMine)"
 
-gem: ${GEM} ## Build the gem package
+forceclean: realclean ## Remove all bundled files and reset Bundler
+	@${BUNDLE} clean --force || :
+
+gem: ${GEM} ## Build the gem package for release
 	@echo ${GEM}
 
 help: ## Display this message
 	@echo "Available make targets:"
 	@grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "%-20s %s\n", $$1, $$2}'
 	@echo ""
-ifdef AWS_PROFILE
-	@echo "Environment variables (optional: all variables have defaults):"
 	@make vars
-else
-	@echo "Warning: AWS_PROFILE environment variable is not set. AWS CLI commands may fail."
-	@echo "Re-run with AWS_PROFILE set to see all variables"
-endif
 
 lint: rubocop ## Run linting checks
-	@echo "All linting complete."
+	@echo "Linting complete."
 
-publish: ${AUTH} ${GEM} ## Publish the gem package to Epimorphics Package Registry
-	@echo Publishing package ${NAME}:${VERSION} to ${OWNER} ...
-	@gem push --key github --host ${GPR} ${GEM}
-	@echo Done.
+publish: ${AUTH} ${GEM} ## Publish the gem to the GitHub Package Registry
+	@echo "Publishing ${GEM} to GitHub Package Registry..."
+	@gem push --key github \
+		--host ${GPR} ${GEM}
+	@echo "Done."
 
-realclean: clean ## Remove authentication files
-	@rm -rf ${AUTH}
+realclean: clean ## Remove all generated files and authentication
+	@echo "Removing authentication..."
+	@rm -f ${AUTH}
 
 rubocop: ## Run RuboCop linting
-	@echo "Running RuboCop linting for ${GEM} ..."
-# Auto-correct offenses safely where possible with the `-a` flag
+	@echo "Running RuboCop linting..."
 	@${BUNDLE} exec rubocop -a
 
-tags: ## Display version information
+tag: ## Display the current gem tag
+	@echo ${TAG}
+
+tags: ## Display version information for CI pipeline
 	@echo version=${VERSION}
 
-test: ## Run tests
+test: ## Run the test suite
 	@echo "Running tests..."
 	@${BUNDLE} exec rake test
 
-update: ## Review and update dependencies interactively
-	@echo "Checking for outdated dependencies..."
-	@if [ -f package.json ]; then \
-		echo "Running yarn upgrade-interactive..."; \
-		yarn upgrade-interactive; \
-	fi
+updates: ## Check for outdated Ruby gems with Bundler
 	@echo "Running bundle outdated to check Ruby gems..."
-# Let bundler handle output; treat this as informational even if deps are outdated
 	@${BUNDLE} outdated --only-explicit || true
 
-vars: ## Display environment variables
-	@echo "GEM"	= ${GEM}
-	@echo "GPR"	= ${GPR}
-	@echo "NAME = ${NAME}"
-	@echo "OWNER = ${OWNER}"
-	@echo "SPEC = ${SPEC}"
-	@echo "VERSION = ${VERSION}"
+vars: ## Display current variable values
+	@echo "COMMIT          = ${COMMIT}"
+	@echo "GEM             = ${GEM}"
+	@echo "GPR             = ${GPR}"
+	@echo "NAME            = ${NAME}"
+	@echo "OWNER           = ${OWNER}"
+	@echo "SPEC            = ${SPEC}"
+	@echo "TAG             = ${TAG}"
+	@echo "VERSION         = ${VERSION}"
+
+version: ## Display the gem version
+	@echo ${VERSION}

--- a/README.md
+++ b/README.md
@@ -2,88 +2,107 @@
 
 ## Understanding json-rails-logger
 
-The json-rails-logger gem transforms Rails application logging from traditional
-plain-text format into structured JSON output. This standardisation is
-particularly valuable in environments where multiple applications need to
-produce logs in a consistent format, making it easier to aggregate, search, and
-analyse logs across different services.
+The json-rails-logger gem replaces Rails' default plain-text log formatter with
+one that serialises every log entry as a structured JSON object. Each entry
+carries predictable fields - timestamp, severity, HTTP method, request path,
+response status - making logs immediately queryable by aggregation tools such as
+Elasticsearch or Kibana without any custom parsing.
 
-At its core, the gem replaces Rails' default logger formatter with one that
-serialises log entries as JSON objects. Each log message becomes a structured
-document with predictable fields like timestamp, severity level, HTTP method,
-request path, and response status. This structured approach eliminates the need
-for complex log parsing and makes the logs immediately queryable by log
-aggregation tools like Elasticsearch, Splunk, or CloudWatch Logs Insights.
+The gem is designed for consistency across Epimorphics' application portfolio.
+All Rails applications using it produce logs in the same JSON structure with the
+same field names, which simplifies operations, monitoring, and cross-service
+debugging.
 
-A key feature of this logger is its handling of request context. It
-automatically captures and includes the request_id in every log entry during an
-HTTP request's lifecycle. This correlation identifier becomes invaluable when
-tracing a single user request through multiple log entries, background jobs, or
-even across microservices. The gem achieves this through middleware that stores
-the request ID in thread-local storage, making it available to the formatter
-without requiring explicit parameter passing throughout the application code.
+> [!TIP]
+> Use the outline icon (☰) at the top right of this page to jump directly to
+> any section.
 
-The design philosophy prioritises consistency across Epimorphics' application
-portfolio. By ensuring all Rails applications output logs in the same JSON
-structure, the organisation gains a unified logging interface that simplifies
-operations, monitoring, and debugging across its entire infrastructure. This
-consistency is particularly beneficial when correlating events across multiple
-applications or when building dashboards that aggregate metrics from various
-sources.
+## Output Format
 
-## Internal structure
+Every log entry is a single-line JSON object. Fields are ordered with `ts`,
+`level`, and `message` first, followed by remaining fields alphabetically.
+Fields are only present when they carry a value - absent fields are omitted
+entirely rather than emitted as `null`.
 
-This logger makes use of [lograge](https://github.com/roidrage/lograge) to
-"attempt to tame Rails' default policy". However, we augment the JSON format
-used by lograge to fit our local requirements, and ensure the HTTP request ID is
-logged where available.
+### Request lifecycle
 
-### Gem API Documentation
+Each incoming HTTP request produces a sequence of log entries sharing a
+`request_id`. The `request_status` field tracks progress through the lifecycle:
 
-The gem includes comprehensive YARD documentation covering all public classes,
-methods, and configuration options. Running `make doc` generates a complete HTML
-reference that provides detailed insights into the gem's internal architecture
-and public API surface. This documentation is particularly valuable when
-customising the logger's behaviour, understanding its integration points with
-Rails, or extending its functionality for specialised use cases.
-
-The generated documentation includes method signatures with parameter types,
-return value specifications, usage examples, and cross-references to related
-Rails and Ruby standard library components. Each public method is annotated with
-practical examples showing common configuration patterns and integration
-scenarios. The documentation also covers thread-safety considerations,
-middleware behaviour, and the gem's interaction with Lograge's internal
-mechanisms.
-
-To explore the full API reference, class hierarchies, and method documentation,
-run `make doc` from the project root. This executes YARD to parse the source
-code annotations and produce browsable HTML output in the `doc/` directory and
-then opens `doc/index.html` in your browser. The generated docs are particularly
-useful when integrating the gem into complex Rails applications or when
-troubleshooting unexpected logging behaviour.
-
-## Installation
-
-This gem is published to the Epimorphics [GitHub Package
-Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-rubygems-registry).
-You'll need to authenticate Bundler with a personal access token (PAT) to fetch
-the gem. See [GitHub Package Registry
-Authentication](CONTRIBUTING.md#github-package-registry-authentication) in
-CONTRIBUTING.md for setup instructions.
-
-In your Rails app, add this to your `Gemfile`:
-
-```ruby
-source "https://rubygems.pkg.github.com/epimorphics" do
-  gem 'json_rails_logger'
-end
+```json
+{"ts":"1970-01-01T00:00:33.722Z","level":"INFO","message":"Received request for /","method":"GET","path":"/","request_id":"c5ff5ecb-0242-4359-88cb-652930d880f6","request_status":"received"}
 ```
 
-And this to your environment config (e.g. `config/environments/production.rb`):
-
-```ruby
-config.logger = JsonRailsLogger::Logger.new(STDOUT)
+```json
+{"ts":"1970-01-01T00:00:34.884Z","level":"INFO","message":"Received response from API with 183 items, time taken: 1094 ms","method":"GET","path":"/catalog/data/dataset?_view=compact","query_string":"_view=compact","request_id":"c5ff5ecb-0242-4359-88cb-652930d880f6","request_status":"processing","request_time":1.094,"returned_rows":183,"status":200}
 ```
+
+```json
+{"ts":"1970-01-01T00:00:35.555Z","level":"INFO","message":"Datasets index request complete, time taken: 1779 ms","method":"GET","path":"/","request_id":"c5ff5ecb-0242-4359-88cb-652930d880f6","request_status":"completed","request_time":1.779,"status":200}
+```
+
+The `request_id` is the correlation thread across all entries for a single
+request, making it straightforward to trace a complete request lifecycle in a
+log aggregation tool. `query_string` appears only when a query string is
+present.
+
+### Common fields
+
+The following fields appear consistently across Epimorphics applications.
+Consuming applications may include additional fields alongside these.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `ts` | string | ISO 8601 timestamp with millisecond precision, UTC |
+| `level` | string | Severity - see [Severity Levels](#severity-levels) |
+| `message` | string | Human-readable description of the event |
+| `method` | string | HTTP method (`GET`, `POST`, etc.) |
+| `path` | string | Request path for inbound entries; full upstream URL for outbound entries (see note below) |
+| `query_string` | string | Query string, when present |
+| `request_id` | string | Correlation ID from the `X-Request-ID` header |
+| `request_status` | string | `received`, `processing`, `completed`, or `error` |
+| `request_time` | float | Time taken in seconds (e.g. `1.094`) |
+| `returned_rows` | integer | Number of rows or items returned |
+| `status` | integer | HTTP response status code |
+
+> [!NOTE]
+> For outbound API requests logged via Faraday or similar HTTP clients,
+> `path` carries the full upstream URL including host and scheme (e.g.
+> `https://api.example.com/data/items`), rather than a relative path.
+> This is set by the consuming application and is distinct from the
+> relative `path` on inbound request entries.
+
+### Structured-only entries
+
+When an application logs purely structured data with no human-readable message
+
+- as Faraday client logging typically does - the `message` field is omitted
+entirely rather than emitted as `null`:
+
+```json
+{"ts":"1970-01-01T00:00:33.787Z","level":"DEBUG","method":"GET","path":"https://api.example.com/catalog/data/dataset?_view=compact","request_id":"c5ff5ecb-0242-4359-88cb-652930d880f6"}
+```
+
+This means log queries or alerting rules that filter on `message` should
+account for entries where the field is absent.
+
+## Severity Levels
+
+Log severity is normalised according to the following mapping:
+
+| Input | Output |
+| --- | --- |
+| `DEBUG`, `TRACE`, `0` | `DEBUG` |
+| `INFO`, `1` | `INFO` |
+| `WARN`, `2` | `WARN` |
+| `ERROR`, `3` | `ERROR` |
+| `FATAL`, `CRITICAL`, `4` | `FATAL` |
+| anything else | `UNKNOWN` |
+
+> [!NOTE]
+> Prior to v3.0.0, `FATAL` was mapped to `ERROR`. From v3.0.0 onwards `FATAL`
+> is preserved. If the log pipeline or alerting rules differentiate on
+> severity, this may need to be updated in those rules when upgrading.
 
 ## How It Works
 
@@ -106,17 +125,11 @@ automatically initialises:
    - Include request exceptions in the JSON payload
    - Disable Rails' default colourised logging
 
-### If You Don't Configure JsonRailsLogger
-
-If you add the gem to your Gemfile but **don't** configure it as your logger:
-
-- **Middleware still runs** (minimal overhead: just thread storage
-  assignment/cleanup)
-- **Lograge remains unconfigured** (Rails uses default logging)
-- **Request ID won't appear in logs** (middleware captures it, but not used
-  without configured logger)
-- **No breaking changes** (gem is safe to include without immediate
-  configuration)
+> [!IMPORTANT]
+> The gem's Railtie configures Lograge at load time, unconditionally setting
+> its formatter, suppressing colourised output, and enabling exception
+> payloads. If Lograge behaviour seems unexpected in an application, this
+> is the first place to look.
 
 ### Thread-Local Storage and Request IDs
 
@@ -130,6 +143,25 @@ several reasons:
 - **No context passing**: The formatter and other components can read the
   request ID without it being passed as a parameter
 
+## Puma Log Formatting
+
+Rails startup and Puma server messages are emitted outside the Rails logger and
+require separate configuration to appear as JSON. Add the following to
+`config/puma.rb`:
+
+```ruby
+log_formatter do |str|
+  {
+    level: 'INFO',
+    ts: Time.now.utc.strftime('%Y-%m-%dT%H:%M:%S.%3NZ'),
+    message: str.strip
+  }.to_json
+end
+```
+
+Without this, Puma startup lines will be emitted as plain text and discarded by
+log aggregation tools that expect well-formed JSON.
+
 ## Filtering Specific Keys from Logs
 
 The json-rails-logger gem provides built-in support for filtering specific keys
@@ -137,7 +169,7 @@ from log output. This is particularly useful for suppressing verbose or
 repetitive fields that clutter logs without adding diagnostic value, removing
 confidential information such as passwords, API keys, and access tokens that
 might be stored or transmitted outside secure boundaries, and for selective
-debugging — by keeping filtered keys hidden in production whilst optionally
+debugging - by keeping filtered keys hidden in production whilst optionally
 preserving them under a debug key for troubleshooting and auditing purposes.
 
 ### Configuration
@@ -173,38 +205,86 @@ config.logger = JsonRailsLogger::Logger.new(
 > The `_filtered` key only appears when `keep_filtered_keys: true` **and** at
 > least one key was filtered.
 
-## Severity Levels
+## Installation
 
-Log severity is normalised according to the following mapping:
+### Requirements
 
-| Input | Output |
-|---|---|
-| `DEBUG`, `TRACE`, `0` | `DEBUG` |
-| `INFO`, `1` | `INFO` |
-| `WARN`, `2` | `WARN` |
-| `ERROR`, `3` | `ERROR` |
-| `FATAL`, `CRITICAL`, `4` | `FATAL` |
-| anything else | `UNKNOWN` |
+- Ruby `>= 3.0.0`
+- Rails `>= 6.0` (via `railties`)
 
-> [!NOTE]
-> Prior to v3.0.0, `FATAL` was mapped to `ERROR`. From v3.0.0 onwards `FATAL`
-> is preserved. If your log pipeline or alerting rules differentiate on
-> severity, you may need to update those rules when upgrading.
+### Setup
+
+This gem is published to the Epimorphics [GitHub Package
+Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-rubygems-registry).
+You'll need to authenticate Bundler with a personal access token (PAT) to fetch
+the gem. See [GitHub Package Registry
+Authentication](CONTRIBUTING.md#github-package-registry-authentication) in
+CONTRIBUTING.md for setup instructions.
+
+In your Rails app, add this to your `Gemfile`:
+
+```ruby
+source "https://rubygems.pkg.github.com/epimorphics" do
+  gem 'json_rails_logger'
+end
+```
+
+And this to your environment config (e.g. `config/environments/production.rb`):
+
+```ruby
+config.logger = JsonRailsLogger::Logger.new(STDOUT)
+```
+
+## Internal Structure
+
+This logger makes use of [lograge](https://github.com/roidrage/lograge) to
+"attempt to tame Rails' default policy". We augment the JSON format used by
+Lograge to fit our local requirements and ensure the HTTP request ID is logged
+where available.
 
 ## Upgrading from v2.x
 
+### All v2.x versions
+
 | v2.x | v3.x |
-|---|---|
-| `JsonFormatter.new(include_ignored_keys: true)` | No direct equivalent — use `filtered_keys:` to suppress specific noisy fields |
+| --- | --- |
 | `JsonFormatter::REQUIRED_KEYS` | `JsonFormatter::EXPECTED_KEYS` |
-| `JsonFormatter::IGNORED_KEYS` | Removed — keys are no longer partitioned into ignored/required buckets |
+| `JsonFormatter::IGNORED_KEYS` | Removed - keys are no longer partitioned into ignored/required buckets |
 | `FATAL` severity → `"ERROR"` in output | `FATAL` severity → `"FATAL"` in output |
+
+### Additionally from v2.3.0
+
+In v2.3.0, `include_ignored_keys: true` was introduced as an opt-in to include
+fields suppressed by default (such as `action`, `controller`, or `user_agent`):
+
+```ruby
+config.logger = JsonRailsLogger::Logger.new(STDOUT, include_ignored_keys: true)
+```
+
+In v3.x this approach is inverted. Rather than opting in to include suppressed
+fields, all fields are included by default and `filtered_keys:` is used to
+explicitly suppress specific ones:
+
+```ruby
+config.logger = JsonRailsLogger::Logger.new(
+  STDOUT,
+  filtered_keys: ['action', 'controller', 'user_agent']
+)
+```
+
+See [Filtering Specific Keys from Logs](#filtering-specific-keys-from-logs) for
+full configuration options.
 
 ## Contributing
 
 For information on setting up a development environment, running tests,
 generating documentation, and publishing releases, see
-[CONTRIBUTING.md](CONTRIBUTING.md)
+[CONTRIBUTING.md](CONTRIBUTING.md).
+
+The gem includes YARD documentation on all public classes and methods. Run
+`make docs` from the project root to generate a browsable HTML reference in the
+`doc/` directory. This is the best starting point when customising the
+formatter, extending the gem, or troubleshooting unexpected behaviour.
 
 [^1]: <https://guides.rubyonrails.org/plugins.html#using-the-railtie> "Rails
     Guides: Using the Railtie – A Railtie is a mechanism to hook into Rails'

--- a/lib/json_rails_logger/formatting_components/payload_builder.rb
+++ b/lib/json_rails_logger/formatting_components/payload_builder.rb
@@ -142,7 +142,7 @@ module JsonRailsLogger
       # @param message [Hash] Message hash to enrich
       # @return [Hash] Enriched message with updated :message and :request_status fields
       #
-      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      # rubocop:disable Metrics/AbcSize
       def enrich_message_with_request_details(message)
         enriched = message.dup
 
@@ -152,16 +152,19 @@ module JsonRailsLogger
           enriched[:request_status] = 'completed' if enriched[:request_status].nil?
         end
 
-        # Add request time to the message if present and not already included
+        # Add request time to the message if present and not already included.
+        # request_time arrives via Lograge in milliseconds as a numeric value.
+        # We append a human-readable ms figure to the message, then store the
+        # value in seconds as a Float to satisfy the logging standard which
+        # requires request_time to be a floating-point number (not a string).
         if enriched[:request_time].present? && enriched[:message].present? && !enriched[:message].include?(', time taken:') # rubocop:disable Layout/LineLength
           enriched[:message] += format(', time taken: %.0f ms', enriched[:request_time])
-          seconds, milliseconds = enriched[:request_time].to_i.divmod(1000)
-          enriched[:request_time] = format('%.0f.%03d', seconds, milliseconds) # rubocop:disable Style/FormatStringToken
+          enriched[:request_time] = (enriched[:request_time] / 1000.0).round(3)
         end
 
         enriched
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+      # rubocop:enable Metrics/AbcSize
 
       # Applies recursive key filtering to the payload based on configuration.
       #
@@ -270,13 +273,14 @@ module JsonRailsLogger
       def reorder_payload(payload)
         reordered = {
           ts: payload[:ts],
-          level: payload[:level],
-          message: payload[:message]
+          level: payload[:level]
         }
-
+        reordered[:message] = payload[:message] unless payload[:message].nil?
+        # Place all other keys after ts, level, and message if not nil sorted
+        # alphabetically, except :_filtered which is kept at the end
         rest = payload.except(:ts, :level, :message, :_filtered).sort.to_h
         filtered = payload.key?(:_filtered) ? { _filtered: payload[:_filtered] } : {}
-
+        # Merge the reordered keys with the remaining keys and the filtered keys at the end
         reordered.merge(rest).merge(filtered)
       end
 

--- a/lib/json_rails_logger/version.rb
+++ b/lib/json_rails_logger/version.rb
@@ -3,7 +3,7 @@
 module JsonRailsLogger
   MAJOR = 3
   MINOR = 0
-  PATCH = 0
+  PATCH = 1
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && "-#{SUFFIX}"}".freeze
 end

--- a/test/formatter_test.rb
+++ b/test/formatter_test.rb
@@ -88,18 +88,6 @@ describe 'JsonRailsLogger::JsonFormatter' do
     _(json_output['request_time']).must_equal(1_234_568)
   end
 
-  it 'should include user_agent and accept from user-agent headers' do
-    formatter = JsonRailsLogger::JsonFormatter.new
-    formatter.datetime_format = '%Y-%m-%dT%H:%M:%S.%3NZ'
-
-    message = "User-Agent: \"Test-Agent\"\nAccept: \"application/json\""
-    log_output = formatter.call('INFO', timestamp, progname, message)
-    json_output = JSON.parse(log_output)
-
-    _(json_output['user_agent']).must_equal('Test-Agent')
-    _(json_output['accept']).must_equal('application/json')
-  end
-
   it 'should handle nil severity without truncation errors' do
     formatter = JsonRailsLogger::JsonFormatter.new
     formatter.datetime_format = '%Y-%m-%dT%H:%M:%S.%3NZ'

--- a/test/formatter_test.rb
+++ b/test/formatter_test.rb
@@ -112,7 +112,7 @@ describe 'JsonRailsLogger::JsonFormatter' do
     _(json_output).must_include('status')
   end
 
-  it 'should handle nil raw message via parser delegation' do
+  it 'should omit message key entirely when raw message is nil' do
     formatter = JsonRailsLogger::JsonFormatter.new
     formatter.datetime_format = '%Y-%m-%dT%H:%M:%S.%3NZ'
 
@@ -121,11 +121,11 @@ describe 'JsonRailsLogger::JsonFormatter' do
 
     _(json_output['ts']).must_equal('2020-12-15T20:15:21.286Z')
     _(json_output['level']).must_equal('INFO')
-    _(json_output['message']).must_be_nil
+    _(json_output.key?('message')).must_equal(false)
   end
 
   it 'should place ts, level, and message first in JSON output' do
-    message = 'Status 200'
+    message = 'Something happened'
 
     log_output = fixture.call('INFO', timestamp, progname, message)
     json_output = JSON.parse(log_output)

--- a/test/formatter_test.rb
+++ b/test/formatter_test.rb
@@ -196,7 +196,7 @@ describe 'JsonRailsLogger::JsonFormatter' do
     _(json_output['method']).must_equal('GET')
     _(json_output['path']).must_equal('/api/datasets/ukhpi/query')
     _(json_output['status']).must_equal(200)
-    _(json_output['request_time']).must_equal('0.146')
+    _(json_output['request_time']).must_equal(0.146)
 
     _(json_output['controller']).must_equal('Api::DatasetsController')
     _(json_output['action']).must_equal('query')
@@ -275,7 +275,7 @@ describe 'JsonRailsLogger::JsonFormatter' do
       _(json_output['method']).must_equal('POST')
       _(json_output['path']).must_equal('/api/exports/csv')
       _(json_output['status']).must_equal(202)
-      _(json_output['request_time']).must_equal('0.089')
+      _(json_output['request_time']).must_equal(0.089)
     ensure
       Thread.current[JsonRailsLogger::REQUEST_ID] = nil
     end


### PR DESCRIPTION
Refine log output to conform to the Epimorphics Logging Standard and overhaul development tooling and documentation to improve developer experience and CI processes.

## What's changed:

*   The `request_time` field was corrected to be emitted as a floating-point number, ensuring consistency with the logging standard's requirement for numeric types. This resolves a type inconsistency where it was previously output as a string.
*   The `message` field is now omitted from log entries when no value is present, such as in structured-only log entries, adhering to the logging standard's requirement for fields to appear only when pertinent.
*   The `Makefile` was extensively rewritten to streamline the gem development workflow. This involved removing application-specific targets, adding essential targets for CI publication (`gem`, `tags`, `docs`), and correcting existing targets for testing, linting, and publishing.
*   The `CONTRIBUTING.md` guide was updated to align with the new `Makefile` targets, provide correct setup instructions, and clarify the gem publication process, enhancing the developer onboarding experience.
*   The `README.md` was substantially restructured to improve its utility for quick reference during incidents. Key information, such as output format and severity levels, was moved to the forefront, and sections for log examples, common fields, Puma configuration, and version requirements were added. The upgrading section now clearly distinguishes changes from v2.x and v2.3.0.
* Updated unit-test.yml workflow to prevent duplicated runs on push & pull-request events at the same time, as well as adjusted the passing in of the secrets to prevent the chance of leaking in the logs.
*   The gem's patch version was incremented to `3.0.1` to reflect these updates and fixes.