### PR TITLE
Spike: Workflow updates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,5 +53,8 @@ jobs:
           json_rails_logger-${{ steps.gitinfo.outputs.version }}.gem
 
     - name: "Publish gem"
-      run: |
-        PAT=${{ secrets.GITHUB_TOKEN }} make publish
+      # Passing the token via env rather than interpolating it directly into
+      # the run string prevents it from appearing in logs or process listings.
+      env:
+        PAT: ${{ secrets.GITHUB_TOKEN }}
+      run: make publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,17 +1,32 @@
 name: Release and Publish Gem
+
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
 
 #---- Below this line should not require editing ----
 jobs:
   build:
     name: "Build gem package"
     runs-on: ubuntu-latest
+    # Prevent accidental releases from feature branches
+    if: github.ref == 'refs/heads/main'
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
+
+    - name: "Record desired ruby version"
+      id: ruby
+      shell: bash
+      run: |
+        [ -f .ruby-version ] && echo version=$(cat .ruby-version) | tee -a $GITHUB_OUTPUT || echo "version=" >> $GITHUB_OUTPUT
+
+    - name: "Setup ruby"
+      if: steps.ruby.outputs.version != ''
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ steps.ruby.outputs.version }}
 
     - name: "Git Information"
       id: gitinfo

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
         make tags                             | tee -a $GITHUB_OUTPUT
 
     - name: "Build gem"
-      run: "make gem"
+      run: make gem
 
     - name: "Create Release"
       id: release

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and severity levels moved to the top. Real log examples, a common fields
   table, Puma configuration guidance, and version requirements added. The
   upgrading section correctly distinguishes v2.x from v2.3.0 changes.
+- Renamed `NAME` to `GEM_NAME` in Makefile to eliminate conflicts with reserved
+  environment variables in Windows Subsystem for Linux
 
 ## [3.0.0] - 2026-03
 

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,17 @@
 .PHONY: all auth build bundles check checks clean coverage docs forceclean gem help lint publish realclean rubocop tag tags test updates vars version
 
-NAME?=json_rails_logger
+GEM_NAME?=json_rails_logger
 OWNER?=epimorphics
 COMMIT=$(shell git rev-parse --short HEAD)
-VERSION?=$(shell /usr/bin/env ruby -e 'require "./lib/${NAME}/version" ; puts JsonRailsLogger::VERSION')
+VERSION?=$(shell /usr/bin/env ruby -e 'require "./lib/${GEM_NAME}/version" ; puts JsonRailsLogger::VERSION')
 TAG?=${VERSION}-${COMMIT}
 PAT?=$(shell read -p 'Github access token:' TOKEN; echo $$TOKEN)
 BUNDLE?=bundle
 
 AUTH=${HOME}/.gem/credentials
-GEM=${NAME}-${VERSION}.gem
+GEM=${GEM_NAME}-${VERSION}.gem
 GPR=https://rubygems.pkg.github.com/${OWNER}
-SPEC=${NAME}.gemspec
+SPEC=${GEM_NAME}.gemspec
 
 ${AUTH}:
 	@mkdir -p ${HOME}/.gem
@@ -20,7 +20,7 @@ ${AUTH}:
 	@chmod 0600 ${AUTH}
 
 # Build the gem package
-${GEM}: ${SPEC} ./lib/${NAME}/version.rb
+${GEM}: ${SPEC} ./lib/${GEM_NAME}/version.rb
 	gem build ${SPEC}
 
 all: check ## Default target: run all checks
@@ -101,8 +101,8 @@ updates: ## Check for outdated Ruby gems with Bundler
 vars: ## Display current variable values
 	@echo "COMMIT          = ${COMMIT}"
 	@echo "GEM             = ${GEM}"
+	@echo "GEM_NAME        = ${GEM_NAME}"
 	@echo "GPR             = ${GPR}"
-	@echo "NAME            = ${NAME}"
 	@echo "OWNER           = ${OWNER}"
 	@echo "SPEC            = ${SPEC}"
 	@echo "TAG             = ${TAG}"


### PR DESCRIPTION
This pull request refines the GitHub Actions workflows to improve security, control, and dependency management for gem publishing and unit tests. It updates action versions, ensures gem builds use the correct Ruby version, and prevents accidental releases from non-main branches.

## What's changed:
*   The publishing workflow is now restricted to the `main` branch, preventing unintended releases from other branches.
*   The Ruby version for gem building was dynamically configured by reading the `.ruby-version` file, ensuring consistency with project requirements.
*   The `GITHUB_TOKEN` for publishing was passed more securely as an environment variable, rather than directly interpolated, to prevent exposure in logs.
*   The `make gem` command syntax was tidied for improved readability.
*   The `checkout` GitHub Action was updated to version `v6` across all relevant workflows, incorporating the latest features and security patches.
*   Renamed `NAME` to `GEM_NAME` in Makefile to eliminate conflicts with reserved environment variables in Windows Subsystem for Linux