### PR TITLE
Spike: Shared workflow update

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,148 @@
+# GitHub Actions Workflows
+
+This directory contains the GitHub Actions workflow definitions for the
+`json_rails_logger` gem. These workflows automate code quality checks, testing,
+and release processes.
+
+## Workflows Overview
+
+| Workflow | File | Trigger | Purpose |
+| --- | --- | --- | --- |
+| Unit Tests | `unit-tests.yml` | Push to main, pull request to main, manual, workflow call | Runs the test suite and linting checks |
+| Rubocop | `rubocop.yml` | Push to main, pull request to main, manual, workflow call | Checks code style compliance |
+| Release and Publish | `publish.yml` | Manual dispatch | Gates on lint and tests, then builds, releases, and publishes the gem |
+
+---
+
+## Unit Tests (`unit-tests.yml`)
+
+**Triggers:**
+
+- Automatically on push and pull request to `main`
+- Manually via the Actions UI or API
+- Called directly by `publish.yml` as a required quality gate
+
+**Purpose:** Installs dependencies, then runs linting and the test suite via
+`make checks` to ensure code changes do not break existing functionality or
+introduce style violations.
+
+### Steps
+
+1. Checks out the repository code with full git history
+2. Detects the required Ruby version from `.ruby-version`
+3. Sets up the Ruby environment
+4. Installs dependencies via `make assets`
+5. Runs linting and tests via `make checks`
+
+### Notes
+
+- The `EPI_GPR_READ_ACCESS_TOKEN` secret is required when called as a reusable
+  workflow, to authenticate with the Epimorphics GitHub Package Registry
+- Push and pull request triggers are restricted to `main` to prevent duplicate
+  runs when a PR is open
+
+---
+
+## Rubocop Compliance (`rubocop.yml`)
+
+**Triggers:**
+
+- Automatically on push and pull request to `main`
+- Manually via the Actions UI or API
+- Called directly by `publish.yml` as a required quality gate
+
+**Purpose:** Enforces Ruby code style and linting standards using Rubocop to
+maintain consistent code quality across the project.
+
+### Steps
+
+1. Checks out the repository code
+2. Sets up the Ruby environment
+3. Installs dependencies via `make assets`
+4. Runs Rubocop with GitHub-formatted output
+
+### Notes
+
+- The workflow will fail if any Rubocop offences are detected
+- Ensure code passes locally with `bundle exec rubocop` before pushing
+
+---
+
+## Release and Publish Gem (`publish.yml`)
+
+**Trigger:** Manual dispatch only (via GitHub Actions UI or API).
+
+**Purpose:** Runs Rubocop compliance and the unit test suite as parallel quality
+gates, then creates a GitHub release and publishes the gem to the GitHub Package
+Registry. Publishing is restricted to the `main` branch; dispatching from
+another branch runs the gates without releasing.
+
+### Jobs
+
+**`verify-rubocop`** — Calls `rubocop.yml` as a reusable workflow. The publish
+job will not proceed unless this completes successfully.
+
+**`verify-unit-tests`** — Calls `unit-tests.yml` as a reusable workflow. The
+publish job will not proceed unless this completes successfully.
+
+**`publish`** — Calls the shared
+[`epimorphics/github-workflows`](https://github.com/epimorphics/github-workflows)
+reusable workflow. Restricted to `main`; skipped silently on all other branches.
+
+### Publish steps (via shared workflow)
+
+1. Checks out the repository with full git history
+2. Detects the required Ruby version from `.ruby-version`
+3. Sets up the Ruby environment
+4. Extracts gem name, owner, and version via `make tags`
+5. Builds the gem package via `make gem`
+6. Creates a GitHub release with auto-generated release notes
+7. Publishes the gem to the GitHub Package Registry via `make publish`
+
+### Prerequisites
+
+- Update the version in `lib/json_rails_logger/version.rb`
+- Update `CHANGELOG.md` with release notes
+- Ensure the commit to release from is on `main`
+
+### How to Trigger
+
+1. Navigate to the **Actions** tab in GitHub
+2. Select **Release and Publish Gem** from the workflow list
+3. Click **Run workflow**
+4. Select the branch (publishing will only proceed if `main` is selected)
+5. Click the green **Run workflow** button
+
+### Outputs
+
+- A new GitHub release tagged with the version number
+- The `.gem` file attached to the release
+- The gem published to the GitHub Package Registry
+
+---
+
+## Troubleshooting
+
+### Tests Failing
+
+- Ensure all dependencies are installed: `make assets`
+- Check that the Ruby version matches `.ruby-version`
+- Verify your PAT is configured for the Epimorphics GitHub Package Registry
+
+### Rubocop Failing
+
+- Run `bundle exec rubocop -a` to auto-correct safe offences
+- Review the Rubocop output for specific violations
+
+### Publish Workflow Failing
+
+- Verify the version number is correctly set in `version.rb`
+- Confirm the workflow was dispatched from `main`
+- Check that no release already exists for the target version
+
+---
+
+## Local Development
+
+For setup instructions, available `make` targets, and guidance on running tests
+and linting locally, see [CONTRIBUTING.md](../../CONTRIBUTING.md).

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,4 +8,4 @@ jobs:
     uses: epimorphics/github-workflows/.github/workflows/publish-gem.yml@v1
     if: github.ref == 'refs/heads/main'
     secrets:
-      github_token: ${{ secrets.GITHUB_TOKEN }}
+      packages_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,15 @@ on:
   workflow_dispatch:
 
 jobs:
+  verify-code:
+    uses: ./.github/workflows/unit-tests.yml
+    secrets:
+      EPI_GPR_READ_ACCESS_TOKEN: ${{ secrets.EPI_GPR_READ_ACCESS_TOKEN }}
   publish:
-    uses: epimorphics/github-workflows/.github/workflows/publish-gem.yml@v1
+    needs: verify-code
+    # Tests always run; publishing is intentionally restricted to main.
+    # Dispatching from another branch lets you verify the gate without releasing.
     if: github.ref == 'refs/heads/main'
+    uses: epimorphics/github-workflows/.github/workflows/publish-gem.yml@v1
     secrets:
       packages_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,4 +15,4 @@ jobs:
     if: github.ref == 'refs/heads/main'
     uses: epimorphics/github-workflows/.github/workflows/publish-gem.yml@v1
     secrets:
-      packages_token: ${{ secrets.GITHUB_TOKEN }}
+      github_pat: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,58 +3,9 @@ name: Release and Publish Gem
 on:
   workflow_dispatch:
 
-#---- Below this line should not require editing ----
 jobs:
-  build:
-    name: "Build gem package"
-    runs-on: ubuntu-latest
-    # Prevent accidental releases from feature branches
+  publish:
+    uses: epimorphics/github-workflows/.github/workflows/publish-gem.yml@v1
     if: github.ref == 'refs/heads/main'
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-
-    - name: "Record desired ruby version"
-      id: ruby
-      shell: bash
-      run: |
-        [ -f .ruby-version ] && echo version=$(cat .ruby-version) | tee -a $GITHUB_OUTPUT || echo "version=" >> $GITHUB_OUTPUT
-
-    - name: "Setup ruby"
-      if: steps.ruby.outputs.version != ''
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ steps.ruby.outputs.version }}
-
-    - name: "Git Information"
-      id: gitinfo
-      run: |
-        echo name=${GITHUB_REF#refs/*/}       | tee -a $GITHUB_OUTPUT
-        echo branch=${GITHUB_REF#refs/heads/} | tee -a $GITHUB_OUTPUT
-        make tags                             | tee -a $GITHUB_OUTPUT
-
-    - name: "Build gem"
-      run: make gem
-
-    - name: "Create Release"
-      id: release
-      uses: softprops/action-gh-release@v2
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ steps.gitinfo.outputs.version }}
-        name: v${{ steps.gitinfo.outputs.version }}
-        generate_release_notes: true
-        draft: false
-        prerelease: false
-        files: |
-          json_rails_logger-${{ steps.gitinfo.outputs.version }}.gem
-
-    - name: "Publish gem"
-      # Passing the token via env rather than interpolating it directly into
-      # the run string prevents it from appearing in logs or process listings.
-      env:
-        PAT: ${{ secrets.GITHUB_TOKEN }}
-      run: make publish
+    secrets:
+      github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,12 +4,16 @@ on:
   workflow_dispatch:
 
 jobs:
-  verify-code:
+  verify-rubocop:
+    uses: ./.github/workflows/rubocop.yml
+  verify-unit-tests:
     uses: ./.github/workflows/unit-tests.yml
     secrets:
       EPI_GPR_READ_ACCESS_TOKEN: ${{ secrets.EPI_GPR_READ_ACCESS_TOKEN }}
   publish:
-    needs: verify-code
+    needs:
+      - verify-rubocop
+      - verify-unit-tests
     # Tests always run; publishing is intentionally restricted to main.
     # Dispatching from another branch lets you verify the gate without releasing.
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,30 @@
+name: Check Rubocop compliance
+
+# Restricting push to specific branches avoids duplicate runs when a PR
+# is open; manual dispatch supports ad hoc checks; workflow_call lets
+# publish.yml gate releases on lint passing.
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  rubocop:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+
+    - name: Install dependencies (bundle)
+      run: make assets
+
+    - name: Run Rubocop
+      run: rubocop --format github

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,6 +7,7 @@ on:
     secrets:
       EPI_GPR_READ_ACCESS_TOKEN:
         required: true
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,11 +1,15 @@
 name: Unit Tests
+# Restricting push to specific branches prevents duplicate runs when a PR
+# is open - without this, both push and pull_request fire on every commit.
 
 on:
+  workflow_call:
+    secrets:
+      EPI_GPR_READ_ACCESS_TOKEN:
+        required: true
   push:
     branches:
       - main
-      # Restricting push to specific branches prevents duplicate runs when a PR
-      # is open - without this, both push and pull_request fire on every commit.
   pull_request:
     branches:
       - main

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -36,11 +36,11 @@ jobs:
           ruby-version: ${{ steps.ruby.outputs.version }}
 
       - name: Install dependencies (bundle)
-        run: bundle install
+        run: make assets
 
       - name: Run checks
         # Passing the token via env rather than interpolating it directly into
         # the run string prevents it from appearing in logs or process listings.
         env:
           PAT: ${{ secrets.EPI_GPR_READ_ACCESS_TOKEN }}
-        run: make lint test
+        run: make checks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.0.2] - 2026-04
-
 ### Changed
 
-- Refactored gem publishing workflow to call the shared reusable workflow
+- Adopted shared reusable workflow for gem publishing via GitHub Actions
+- Added Rubocop compliance as a required gate before publishing
+- Extended unit test and Rubocop workflows with manual dispatch and reusable call support
+- Scoped push and pull request triggers to the main branch to prevent duplicate CI runs
+- Standardised build flow to orchestrate verification, packaging, and cleaning as a single step
 - Extended Makefile `tags` target to expose gem name and owner for the CI pipeline
 - Updated rake dependency to the latest version
+- Documented Makefile target intent and the separation of verification, packaging, and publishing
+- Added GitHub Actions workflows README covering trigger behaviour and the release process
+- Restructured README for faster incident-response orientation with a front-loaded quick start, known-good lifecycle sample, triage checklist, and consumer app smoke check
+- Updated CONTRIBUTING to correct the setup command from `make bundles` to `make assets` and align all Makefile target references
 
 ## [3.0.1] - 2026-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
+
+## [3.0.2] - 2026-04
+
+### Changed
+
+- Refactored gem publishing workflow to call the shared reusable workflow
+- Extended Makefile `tags` target to expose gem name and owner for the CI pipeline
+- Updated rake dependency to the latest version
 
 ## [3.0.1] - 2026-04
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,17 +86,19 @@ scenarios.
 
 To publish a new version of the gem after a bugfix or feature addition:
 
-1. Ensure the version in `lib/json_rails_logger/version.rb` has been updated to
-   reflect the correct semver representing the change
-2. Update the `CHANGELOG.md` to document the new change
-3. `git tag` the new state with a tag that matches the new version
-4. Push the new tagged release to GitHub
+1. Update the version in `lib/json_rails_logger/version.rb` to reflect the
+   correct semver representing the change
+2. Update `CHANGELOG.md` to document the new change
+3. Run `make build` locally to verify linting and tests pass before releasing
+4. Merge the changes to `main`
+5. Trigger the **Release and Publish Gem** workflow manually via the GitHub
+   Actions UI — see the [workflows README](.github/workflows/README.md) for
+   full instructions
 
-Pushing a tagged version will automatically trigger the publish gem workflow,
-which should result in the gem appearing on the [list of
-releases](https://github.com/epimorphics/json-rails-logger/releases). If the
-workflow does not trigger or needs to be run manually, `make publish` will build
-and push the gem directly to the GitHub Package Registry.
+The workflow runs Rubocop and the test suite as parallel quality gates before
+publishing. The gem will appear on the [list of
+releases](https://github.com/epimorphics/json-rails-logger/releases) once
+complete.
 
 [^‡]: See [notes on the Epimorphics internal wiki](https://github.com/epimorphics/internal/wiki/Ansible-CICD#creating-a-pat-for-gpr-access)
 about creating a PAT.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,19 +2,19 @@
 
 This guide covers development workflow for the json-rails-logger gem.
 
-## Getting Started
+## Getting started
 
 After cloning the repository:
 
-### Install Dependencies
+### Install dependencies
 
 ```sh
-make bundles
+make assets
 ```
 
 This installs all required gems via Bundler.
 
-### GitHub Package Registry Authentication
+### GitHub Package Registry authentication
 
 This gem is published to the Epimorphics GitHub Package Registry. This allows us
 to publish and use Rubygems that we create in our own apps without publishing
@@ -50,9 +50,9 @@ make auth
 The same mechanism is used by the CI publication workflow, where the PAT is
 supplied automatically via `secrets.GITHUB_TOKEN`.
 
-## Development Workflow
+## Development workflow
 
-### `Makefile` Commands
+### `Makefile` commands
 
 The project includes a `Makefile` with common development tasks:
 
@@ -67,13 +67,13 @@ The project includes a `Makefile` with common development tasks:
 - `make test` — Run the test suite
 - `make updates` — Check for outdated Ruby gems
 
-## API Documentation
+## API documentation
 
 The gem includes comprehensive YARD documentation on all public methods:
 
 - **In your IDE**: Hover over `Logger.new` or `JsonFormatter.call` to see
   parameter types and usage examples
-- **As HTML docs**: Run `make doc` to generate human-readable API reference in
+- **As HTML docs**: Run `make docs` to generate human-readable API reference in
   `doc/index.html`
 
 The generated documentation includes method signatures with parameter types,
@@ -82,7 +82,7 @@ Rails and Ruby standard library components. Each public method is annotated with
 practical examples showing common configuration patterns and integration
 scenarios.
 
-## Publishing a New Version
+## Publishing a new version
 
 To publish a new version of the gem after a bugfix or feature addition:
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,7 @@ GEM
       tsort (>= 0.2)
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
-    rake (13.3.1)
+    rake (13.4.2)
     rbs (3.10.3)
       logger
       tsort

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all auth build bundles check checks clean coverage docs forceclean gem help lint publish realclean rubocop tag tags test updates vars version
+.PHONY: all assets auth build check checks clean coverage docs forceclean gem help lint publish realclean rubocop tag tags test updates vars version
 
 GEM_NAME?=json_rails_logger
 OWNER?=epimorphics
@@ -25,17 +25,16 @@ ${GEM}: ${SPEC} ./lib/${GEM_NAME}/version.rb
 
 all: check ## Default target: run all checks
 
+assets:
+	@echo "Installing assets for ${GEM_NAME} gem..."
+	@bundle install
+	@echo "Assets for ${GEM_NAME} gem are up to date."
+
 auth: ${AUTH} ## Set up authentication for GitHub and Bundler
 	@echo "Authentication set up for GitHub and Bundler."
 
-build: ## Build the gem
-	@echo "Building ${GEM} ..."
-	@${BUNDLE} exec gem build ${SPEC}
-	@echo "Done."
-
-bundles: ## Install Ruby gems via Bundler
-	@echo "Installing Ruby gems via Bundler..."
-	@${BUNDLE} install
+build: clean checks gem ## Verify and build the gem
+	@echo "Build and verification complete."
 
 check: checks ## Alias for checks target
 
@@ -44,6 +43,7 @@ checks: lint test ## Run all checks: linting and tests
 
 clean: ## Remove generated files
 	@echo "Cleaning up..."
+	@bundle exec rake clean clobber
 	@rm -rf coverage doc *.gem
 
 coverage: ## Display test coverage report
@@ -92,7 +92,7 @@ tags: ## Display version information for CI pipeline
 	@echo owner=${OWNER}
 	@echo version=${VERSION}
 
-test: ## Run the test suite
+test: assets ## Run the test suite
 	@echo "Running tests..."
 	@${BUNDLE} exec rake test
 

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,8 @@ tag: ## Display the current gem tag
 	@echo ${TAG}
 
 tags: ## Display version information for CI pipeline
+	@echo name=${GEM_NAME}
+	@echo owner=${OWNER}
 	@echo version=${VERSION}
 
 test: ## Run the test suite

--- a/README.md
+++ b/README.md
@@ -331,18 +331,18 @@ source "https://rubygems.pkg.github.com/epimorphics" do
 end
 ```
 
-And this to your environment config (e.g. `config/environments/production.rb`):
+And this to your environment config (for example
+`config/environments/production.rb`):
 
 ```ruby
 config.logger = JsonRailsLogger::Logger.new(STDOUT)
 ```
 
-## Internal Structure
+## Internal structure
 
-This logger makes use of [lograge](https://github.com/roidrage/lograge) to
-"attempt to tame Rails' default policy". We augment the JSON format used by
-Lograge to fit our local requirements and ensure the HTTP request ID is logged
-where available.
+This logger uses [lograge](https://github.com/roidrage/lograge) to replace
+Rails default output and augment JSON formatting for Epimorphics requirements,
+including request ID capture where available.
 
 ## Upgrading from v2.x
 

--- a/README.md
+++ b/README.md
@@ -1,33 +1,136 @@
 # JSON log formatter for Rails
 
+## 2am incident quick start
+
+If alarms are firing and you need to confirm whether logger behaviour is a
+contributor, use this path first:
+
+Makefile path:
+
+```sh
+make assets
+make lint
+make test
+```
+
+Direct targeted tests:
+
+```sh
+bundle exec rake test TEST=test/formatter_test.rb
+bundle exec rake test TEST=test/middleware_test.rb
+```
+
+### Known-good lifecycle sample
+
+Use this as a quick visual check for expected request progression under one
+`request_id`:
+
+```json
+{"ts":"1970-01-01T00:00:33.722Z","level":"INFO","message":"Received request for /","method":"GET","path":"/","request_id":"c5ff5ecb-0242-4359-88cb-652930d880f6","request_status":"received"}
+{"ts":"1970-01-01T00:00:34.884Z","level":"INFO","message":"Received response from API with 183 items, time taken: 1094 ms","method":"GET","path":"/catalog/data/dataset?_view=compact","query_string":"_view=compact","request_id":"c5ff5ecb-0242-4359-88cb-652930d880f6","request_status":"processing","request_time":1.094,"returned_rows":183,"status":200}
+{"ts":"1970-01-01T00:00:35.555Z","level":"INFO","message":"Datasets index request complete, time taken: 1779 ms","method":"GET","path":"/","request_id":"c5ff5ecb-0242-4359-88cb-652930d880f6","request_status":"completed","request_time":1.779,"status":200}
+```
+
+Expected outcome:
+
+- Linting exits cleanly
+- Test suite passes
+- Formatter tests confirm expected JSON structure and severity mapping
+- Middleware tests confirm request ID propagation and cleanup
+
+If these checks pass, the logger gem is less likely to be the primary source of
+an incident, and focus should move to consuming application logic, upstream
+services, or log transport and alerting configuration.
+
+## Is this gem likely the source?
+
+Likely:
+
+- Log lines are no longer valid single-line JSON
+- Expected fields such as `ts`, `level`, or `request_id` are missing
+- Severity values differ from documented mapping and alert thresholds
+- Request lifecycle correlation is broken for a single `request_id`
+
+Less likely:
+
+- Upstream service latency or 5xx rates changed, but log structure is stable
+- Consumer application business logic is failing with correctly formatted logs
+- Log shipper or indexing pipeline is down or dropping messages
+
+## Local verification path
+
+### Requirements
+
+- Ruby `>= 3.0.0`
+- Rails `>= 6.0` (via `railties`)
+- Bundler authenticated to the Epimorphics GitHub Package Registry
+
+See [GitHub Package Registry
+Authentication](CONTRIBUTING.md#github-package-registry-authentication) in
+CONTRIBUTING.md.
+
+### Verify in 5 minutes
+
+```sh
+make assets
+make check
+```
+
+`make check` runs both linting and tests.
+
+### Targeted behaviour checks
+
+```sh
+bundle exec rake test TEST=test/formatter_test.rb
+bundle exec rake test TEST=test/logger_test.rb
+bundle exec rake test TEST=test/middleware_test.rb
+```
+
+These tests give fast confidence in the core behaviours most likely to trigger
+logging alarms.
+
+### Consumer app smoke check
+
+In a Rails host application using this gem, issue one request and verify logs
+contain valid JSON entries with stable `request_id`, expected `request_status`
+transitions, and mapped `level` values.
+
+## Fast triage checklist
+
+1. Confirm the deployed logger gem version changed
+2. Validate consuming app still initialises `JsonRailsLogger::Logger`
+3. Confirm expected severity mapping still matches alerting rules
+4. Check `filtered_keys` changes did not remove alert-critical fields
+5. Verify Puma log formatting if startup logs must remain JSON
+
 ## Understanding json-rails-logger
 
 The json-rails-logger gem replaces Rails' default plain-text log formatter with
 one that serialises every log entry as a structured JSON object. Each entry
-carries predictable fields - timestamp, severity, HTTP method, request path,
-response status - making logs immediately queryable by aggregation tools such as
-Elasticsearch or Kibana without any custom parsing.
+carries predictable fields such as timestamp, severity, HTTP method, request
+path, and response status, making logs queryable by aggregation tools such as
+Elasticsearch or Kibana without custom parsing.
 
-The gem is designed for consistency across Epimorphics' application portfolio.
-All Rails applications using it produce logs in the same JSON structure with the
-same field names, which simplifies operations, monitoring, and cross-service
+The gem is designed for consistency across Epimorphics applications. Rails
+applications using it produce logs in the same JSON structure with the same
+field names, which simplifies operations, monitoring, and cross-service
 debugging.
 
 > [!TIP]
 > Use the outline icon (☰) at the top right of this page to jump directly to
 > any section.
 
-## Output Format
+## Output format
 
 Every log entry is a single-line JSON object. Fields are ordered with `ts`,
 `level`, and `message` first, followed by remaining fields alphabetically.
-Fields are only present when they carry a value - absent fields are omitted
-entirely rather than emitted as `null`.
+Fields are only present when they carry a value. Absent fields are omitted
+rather than emitted as `null`.
 
 ### Request lifecycle
 
 Each incoming HTTP request produces a sequence of log entries sharing a
-`request_id`. The `request_status` field tracks progress through the lifecycle:
+`request_id`. The `request_status` field tracks progress through the lifecycle.
 
 ```json
 {"ts":"1970-01-01T00:00:33.722Z","level":"INFO","message":"Received request for /","method":"GET","path":"/","request_id":"c5ff5ecb-0242-4359-88cb-652930d880f6","request_status":"received"}

--- a/README.md
+++ b/README.md
@@ -146,8 +146,7 @@ Each incoming HTTP request produces a sequence of log entries sharing a
 
 The `request_id` is the correlation thread across all entries for a single
 request, making it straightforward to trace a complete request lifecycle in a
-log aggregation tool. `query_string` appears only when a query string is
-present.
+log aggregation tool. `query_string` appears only when present.
 
 ### Common fields
 

--- a/README.md
+++ b/README.md
@@ -156,30 +156,27 @@ Consuming applications may include additional fields alongside these.
 | Field | Type | Description |
 | --- | --- | --- |
 | `ts` | string | ISO 8601 timestamp with millisecond precision, UTC |
-| `level` | string | Severity - see [Severity Levels](#severity-levels) |
+| `level` | string | Severity, see [Severity Levels](#severity-levels) |
 | `message` | string | Human-readable description of the event |
 | `method` | string | HTTP method (`GET`, `POST`, etc.) |
-| `path` | string | Request path for inbound entries; full upstream URL for outbound entries (see note below) |
+| `path` | string | Request path for inbound entries, full upstream URL for outbound entries |
 | `query_string` | string | Query string, when present |
 | `request_id` | string | Correlation ID from the `X-Request-ID` header |
 | `request_status` | string | `received`, `processing`, `completed`, or `error` |
-| `request_time` | float | Time taken in seconds (e.g. `1.094`) |
+| `request_time` | float | Time taken in seconds (for example `1.094`) |
 | `returned_rows` | integer | Number of rows or items returned |
 | `status` | integer | HTTP response status code |
 
 > [!NOTE]
 > For outbound API requests logged via Faraday or similar HTTP clients,
-> `path` carries the full upstream URL including host and scheme (e.g.
+> `path` carries the full upstream URL including host and scheme (for example
 > `https://api.example.com/data/items`), rather than a relative path.
-> This is set by the consuming application and is distinct from the
-> relative `path` on inbound request entries.
 
 ### Structured-only entries
 
-When an application logs purely structured data with no human-readable message
-
-- as Faraday client logging typically does - the `message` field is omitted
-entirely rather than emitted as `null`:
+When an application logs purely structured data with no human-readable message,
+as Faraday client logging typically does, the `message` field is omitted rather
+than emitted as `null`.
 
 ```json
 {"ts":"1970-01-01T00:00:33.787Z","level":"DEBUG","method":"GET","path":"https://api.example.com/catalog/data/dataset?_view=compact","request_id":"c5ff5ecb-0242-4359-88cb-652930d880f6"}
@@ -188,9 +185,9 @@ entirely rather than emitted as `null`:
 This means log queries or alerting rules that filter on `message` should
 account for entries where the field is absent.
 
-## Severity Levels
+## Severity levels
 
-Log severity is normalised according to the following mapping:
+Log severity is normalised according to the following mapping.
 
 | Input | Output |
 | --- | --- |
@@ -203,53 +200,48 @@ Log severity is normalised according to the following mapping:
 
 > [!NOTE]
 > Prior to v3.0.0, `FATAL` was mapped to `ERROR`. From v3.0.0 onwards `FATAL`
-> is preserved. If the log pipeline or alerting rules differentiate on
-> severity, this may need to be updated in those rules when upgrading.
+> is preserved. If alerting rules differentiate on severity, those rules may
+> need to be updated when upgrading.
 
-## How It Works
+## How it works
 
-### Automatic Railtie Setup
+### Automatic Railtie setup
 
 When `json_rails_logger` is required in your Gemfile, a Rails Railtie[^1]
 automatically initialises:
 
 1. **Middleware insertion**: The `RequestIdMiddleware` is inserted into your
    middleware stack
-   - Automatically reads the HTTP `X-Request-ID` header (production) or
+   - Reads the HTTP `X-Request-ID` header (production) or
      `action_dispatch.request_id` (development)
-   - Stores the request ID in thread-local storage for access during request
-     processing
+   - Stores the request ID in thread-local storage for request processing
    - Cleans up after each request to prevent data leaking in thread pools
 
 2. **Lograge configuration**: If a `JsonRailsLogger::Logger` is configured,
    Lograge is also set up to:
    - Output all log lines in JSON format
    - Include request exceptions in the JSON payload
-   - Disable Rails' default colourised logging
+   - Disable Rails default colourised logging
 
 > [!IMPORTANT]
-> The gem's Railtie configures Lograge at load time, unconditionally setting
-> its formatter, suppressing colourised output, and enabling exception
-> payloads. If Lograge behaviour seems unexpected in an application, this
-> is the first place to look.
+> The gem's Railtie configures Lograge at load time, setting formatter,
+> suppressing colourised output, and enabling exception payloads. If Lograge
+> behaviour seems unexpected in an application, inspect this first.
 
-### Thread-Local Storage and Request IDs
+### Thread-local storage and request IDs
 
 The request ID is stored in `Thread.current[JsonRailsLogger::REQUEST_ID]` for
 several reasons:
 
-- **Thread isolation**: Each request thread has its own request ID; no
-  cross-request pollution
-- **Automatic cleanup**: The ensure block in the middleware guarantees cleanup
-  even if exceptions occur
-- **No context passing**: The formatter and other components can read the
-  request ID without it being passed as a parameter
+- **Thread isolation**: Each request thread has its own request ID
+- **Automatic cleanup**: Middleware ensure block guarantees cleanup
+- **No context passing**: Formatter and related components can read request ID
+  without explicit parameter passing
 
-## Puma Log Formatting
+## Puma log formatting
 
 Rails startup and Puma server messages are emitted outside the Rails logger and
-require separate configuration to appear as JSON. Add the following to
-`config/puma.rb`:
+require separate configuration to appear as JSON. Add this to `config/puma.rb`:
 
 ```ruby
 log_formatter do |str|
@@ -261,18 +253,14 @@ log_formatter do |str|
 end
 ```
 
-Without this, Puma startup lines will be emitted as plain text and discarded by
-log aggregation tools that expect well-formed JSON.
+Without this, Puma startup lines are plain text and may be discarded by log
+aggregation tools expecting well-formed JSON.
 
-## Filtering Specific Keys from Logs
+## Filtering specific keys from logs
 
-The json-rails-logger gem provides built-in support for filtering specific keys
-from log output. This is particularly useful for suppressing verbose or
-repetitive fields that clutter logs without adding diagnostic value, removing
-confidential information such as passwords, API keys, and access tokens that
-might be stored or transmitted outside secure boundaries, and for selective
-debugging - by keeping filtered keys hidden in production whilst optionally
-preserving them under a debug key for troubleshooting and auditing purposes.
+The json-rails-logger gem provides support for filtering specific keys from log
+output. This is useful for suppressing noisy fields, removing confidential
+information, and preserving selected filtered values for controlled debugging.
 
 ### Configuration
 
@@ -292,7 +280,7 @@ config.logger = JsonRailsLogger::Logger.new(
 )
 # Output: {"ts":"...","level":"INFO","message":"User logged in"}
 
-# Option 3: Remove keys but preserve under :_filtered for debugging
+# Option 3: Remove keys and preserve under :_filtered for debugging
 config.logger = JsonRailsLogger::Logger.new(
   STDOUT,
   filtered_keys: ['password', 'api_key'],
@@ -302,26 +290,17 @@ config.logger = JsonRailsLogger::Logger.new(
 ```
 
 > [!IMPORTANT]
-> **Key matching** is exact and case-sensitive. Both string and
-> symbol keys are supported (`['password']` and `[:password]` are equivalent).
-> The `_filtered` key only appears when `keep_filtered_keys: true` **and** at
-> least one key was filtered.
+> Key matching is exact and case-sensitive. Both string and symbol keys are
+> supported (`['password']` and `[:password]` are equivalent). The `_filtered`
+> key only appears when `keep_filtered_keys: true` and at least one key was
+> filtered.
 
 ## Installation
 
-### Requirements
-
-- Ruby `>= 3.0.0`
-- Rails `>= 6.0` (via `railties`)
-
-### Setup
-
 This gem is published to the Epimorphics [GitHub Package
 Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-rubygems-registry).
-You'll need to authenticate Bundler with a personal access token (PAT) to fetch
-the gem. See [GitHub Package Registry
-Authentication](CONTRIBUTING.md#github-package-registry-authentication) in
-CONTRIBUTING.md for setup instructions.
+
+### Setup
 
 In your Rails app, add this to your `Gemfile`:
 
@@ -351,8 +330,8 @@ including request ID capture where available.
 | v2.x | v3.x |
 | --- | --- |
 | `JsonFormatter::REQUIRED_KEYS` | `JsonFormatter::EXPECTED_KEYS` |
-| `JsonFormatter::IGNORED_KEYS` | Removed - keys are no longer partitioned into ignored/required buckets |
-| `FATAL` severity → `"ERROR"` in output | `FATAL` severity → `"FATAL"` in output |
+| `JsonFormatter::IGNORED_KEYS` | Removed, no ignored/required partition |
+| `FATAL` severity maps to `ERROR` | `FATAL` severity maps to `FATAL` |
 
 ### Additionally from v2.3.0
 
@@ -363,9 +342,8 @@ fields suppressed by default (such as `action`, `controller`, or `user_agent`):
 config.logger = JsonRailsLogger::Logger.new(STDOUT, include_ignored_keys: true)
 ```
 
-In v3.x this approach is inverted. Rather than opting in to include suppressed
-fields, all fields are included by default and `filtered_keys:` is used to
-explicitly suppress specific ones:
+In v3.x this approach is inverted. Fields are included by default and
+`filtered_keys:` is used to explicitly suppress specific ones:
 
 ```ruby
 config.logger = JsonRailsLogger::Logger.new(
@@ -379,16 +357,14 @@ full configuration options.
 
 ## Contributing
 
-For information on setting up a development environment, running tests,
-generating documentation, and publishing releases, see
+For setup, development workflow, and release process, see
 [CONTRIBUTING.md](CONTRIBUTING.md).
 
 The gem includes YARD documentation on all public classes and methods. Run
 `make docs` from the project root to generate a browsable HTML reference in the
-`doc/` directory. This is the best starting point when customising the
-formatter, extending the gem, or troubleshooting unexpected behaviour.
+`doc/` directory.
 
 [^1]: <https://guides.rubyonrails.org/plugins.html#using-the-railtie> "Rails
-    Guides: Using the Railtie – A Railtie is a mechanism to hook into Rails'
-    initialization process, allowing gems to run setup code automatically when
+    Guides: Using the Railtie, a Railtie is a mechanism to hook into Rails
+    initialisation process, allowing gems to run setup code automatically when
     Rails boots"

--- a/lib/json_rails_logger/version.rb
+++ b/lib/json_rails_logger/version.rb
@@ -3,7 +3,7 @@
 module JsonRailsLogger
   MAJOR = 3
   MINOR = 0
-  PATCH = 2
+  PATCH = 1
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && "-#{SUFFIX}"}".freeze
 end

--- a/lib/json_rails_logger/version.rb
+++ b/lib/json_rails_logger/version.rb
@@ -3,7 +3,7 @@
 module JsonRailsLogger
   MAJOR = 3
   MINOR = 0
-  PATCH = 1
+  PATCH = 2
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && "-#{SUFFIX}"}".freeze
 end


### PR DESCRIPTION
This pull request refactors and improves the CI/CD workflows, developer documentation, and Makefile for the `json_rails_logger` gem. The main goals are to modernise and modularise the GitHub Actions workflows using reusable components, clarify local development and publishing processes, and make the Makefile more consistent and robust. Additionally, the documentation has been expanded for both troubleshooting and rapid incident response.

**CI/CD Workflow Modernisation and Refactoring:**

- Updated `.github/workflows/publish.yml` to use reusable workflows for Rubocop and unit tests as quality gates, and to delegate publishing to a shared workflow, ensuring only the `main` branch can trigger a release.
- Added `.github/workflows/rubocop.yml` as a standalone workflow for Rubocop checks, supporting manual and reusable invocation.
- Improved `.github/workflows/unit-tests.yml` to use `make assets` and `make checks` for setup and testing, and support secrets for private gem registry access. [[1]](diffhunk://#diff-cd0effce06f425599e96952f4d5f684641a683f46d9909e7c74a9f8b2f03ccd3R2-L8) [[2]](diffhunk://#diff-cd0effce06f425599e96952f4d5f684641a683f46d9909e7c74a9f8b2f03ccd3L35-R47)
- Added a comprehensive `.github/workflows/README.md` describing each workflow, triggers, and troubleshooting steps.

**Makefile and Local Development Enhancements:**

- Refactored the `Makefile` to add an `assets` target (for dependency installation), update `build` to depend on checks, and expose gem metadata for CI via the `tags` target. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L1-R1) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R28-R37) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R46) [[4]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R91-R95)
- Updated `CONTRIBUTING.md` to clarify setup, Makefile usage, and the new publishing process via manual workflow dispatch. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L5-R17) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L53-R55) [[3]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L70-R76) [[4]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L85-R101)

**Documentation and Troubleshooting Improvements:**

- Expanded `README.md` with a "2am incident quick start" section, fast triage checklist, and clearer local verification instructions for rapid troubleshooting. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R3-R133) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L46-R149)
- Updated `CHANGELOG.md` to document the workflow and Makefile changes.

**Summary of Most Important Changes:**

**1. CI/CD Workflow Modernisation**
- Refactored `publish.yml` to use reusable workflows for Rubocop and unit tests as gates, and to call a shared publish workflow, restricting publishing to the `main` branch.
- Added standalone Rubocop workflow (`rubocop.yml`) and improved unit test workflow to use Makefile targets and support secrets for private registry access. [[1]](diffhunk://#diff-b79dca49270186d1f5b31d431888b2811a16786f6d590f1a5220507d3de190cbR1-R30) [[2]](diffhunk://#diff-cd0effce06f425599e96952f4d5f684641a683f46d9909e7c74a9f8b2f03ccd3R2-L8) [[3]](diffhunk://#diff-cd0effce06f425599e96952f4d5f684641a683f46d9909e7c74a9f8b2f03ccd3L35-R47)
- Added detailed documentation for all workflows in `.github/workflows/README.md`.

**2. Makefile and Local Development**
- Added `assets` target, refactored build/test/lint targets for consistency, and made `tags` target emit gem metadata for CI. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L1-R1) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R28-R37) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R46) [[4]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R91-R95)
- Updated `CONTRIBUTING.md` to clarify setup and new workflow-driven publishing. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L5-R17) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L53-R55) [[3]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L70-R76) [[4]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L85-R101)

**3. Documentation and Troubleshooting**
- Expanded `README.md` with incident response, troubleshooting, and verification checklists for rapid triage. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R3-R133) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L46-R149)
- Updated `CHANGELOG.md` to reflect workflow and Makefile changes.